### PR TITLE
Issue 200 create support and feedback pages

### DIFF
--- a/src/app/(dashboard)/feedback/page.tsx
+++ b/src/app/(dashboard)/feedback/page.tsx
@@ -1,5 +1,4 @@
 import { FeedbackScreen } from '@/src/components/Dashboard/Feedback'
-import React from 'react'
 
 const FeedbackPage = () => {
   return (

--- a/src/app/(dashboard)/feedback/page.tsx
+++ b/src/app/(dashboard)/feedback/page.tsx
@@ -1,0 +1,10 @@
+import { FeedbackScreen } from '@/src/components/Dashboard/Feedback'
+import React from 'react'
+
+const FeedbackPage = () => {
+  return (
+    <FeedbackScreen />
+  )
+}
+
+export default FeedbackPage

--- a/src/app/(dashboard)/support/page.tsx
+++ b/src/app/(dashboard)/support/page.tsx
@@ -1,0 +1,10 @@
+import { SupportScreen } from '@/src/components/Dashboard/Support'
+import React from 'react'
+
+const SupportPage = () => {
+  return (
+    <SupportScreen />
+  )
+}
+
+export default SupportPage

--- a/src/app/(dashboard)/support/page.tsx
+++ b/src/app/(dashboard)/support/page.tsx
@@ -1,5 +1,4 @@
 import { SupportScreen } from '@/src/components/Dashboard/Support'
-import React from 'react'
 
 const SupportPage = () => {
   return (

--- a/src/components/Dashboard/Feedback/index.tsx
+++ b/src/components/Dashboard/Feedback/index.tsx
@@ -3,8 +3,6 @@ import {CardTitle } from "@/src/components/ui/card";
 
 export function FeedbackScreen() {
   return (
-    <div>
-        <CardTitle>Feedback</CardTitle>
-    </div>
+    <CardTitle>Feedback</CardTitle>
   );
 }

--- a/src/components/Dashboard/Feedback/index.tsx
+++ b/src/components/Dashboard/Feedback/index.tsx
@@ -1,13 +1,10 @@
 "use client";
-import { CardHeader, CardTitle } from "@/src/components/ui/card";
+import {CardTitle } from "@/src/components/ui/card";
 
 export function FeedbackScreen() {
   return (
-    <div className="h-auto flex flex-col">
-      <CardHeader className="pl-0">
+    <div>
         <CardTitle>Feedback</CardTitle>
-      </CardHeader>
-      {/* Content will be added later. */}
     </div>
   );
 }

--- a/src/components/Dashboard/Feedback/index.tsx
+++ b/src/components/Dashboard/Feedback/index.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { CardHeader, CardTitle } from "@/src/components/ui/card";
+
+export function FeedbackScreen() {
+  return (
+    <div className="h-auto flex flex-col">
+      <CardHeader className="pl-0">
+        <CardTitle>Feedback</CardTitle>
+      </CardHeader>
+      {/* Content will be added later. */}
+    </div>
+  );
+}

--- a/src/components/Dashboard/Sidebar.tsx/constants/NavigationRoutes.ts
+++ b/src/components/Dashboard/Sidebar.tsx/constants/NavigationRoutes.ts
@@ -123,12 +123,12 @@ export const siteRoutes: SiteRoutes = {
   navSecondary: [
     {
       title: "Support",
-      url: "#",
+      url: "/support",
       icon: LifeBuoy
     },
     {
       title: "Feedback",
-      url: "#",
+      url: "/feedback",
       icon: Send
     }
   ]

--- a/src/components/Dashboard/Support/index.tsx
+++ b/src/components/Dashboard/Support/index.tsx
@@ -1,13 +1,10 @@
 "use client";
-import { CardHeader, CardTitle } from "@/src/components/ui/card";
+import { CardTitle } from "@/src/components/ui/card";
 
 export function SupportScreen() {
   return (
-    <div className="h-auto flex flex-col">
-      <CardHeader className="pl-0">
+    <div>
         <CardTitle>Support</CardTitle>
-      </CardHeader>
-      {/* Content will be added later. */}
     </div>
   );
 }

--- a/src/components/Dashboard/Support/index.tsx
+++ b/src/components/Dashboard/Support/index.tsx
@@ -3,8 +3,6 @@ import { CardTitle } from "@/src/components/ui/card";
 
 export function SupportScreen() {
   return (
-    <div>
-        <CardTitle>Support</CardTitle>
-    </div>
+    <CardTitle>Support</CardTitle>
   );
 }

--- a/src/components/Dashboard/Support/index.tsx
+++ b/src/components/Dashboard/Support/index.tsx
@@ -1,0 +1,13 @@
+"use client";
+import { CardHeader, CardTitle } from "@/src/components/ui/card";
+
+export function SupportScreen() {
+  return (
+    <div className="h-auto flex flex-col">
+      <CardHeader className="pl-0">
+        <CardTitle>Support</CardTitle>
+      </CardHeader>
+      {/* Content will be added later. */}
+    </div>
+  );
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -88,6 +88,18 @@ export const pageMeta = [
     url: "/connections",
     title: "Connections",
     description: "connections"
+  },
+  {
+    id: "feedback",
+    url: "/feedback",
+    title: "Feedback",
+    description: "feedback"
+  },
+  {
+    id: "support",
+    url: "/support",
+    title: "Support",
+    description: "support"
   }
 ]
 


### PR DESCRIPTION
I have created the Feedback and Support pages and added their entry to pageMeta in constants.ts to enable the "Spark > Feedback" and "Spark > Support" breadcrumb.