### PR TITLE
SPRK-150: Fix the alignment of 3 dots for channels in community details page

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
@@ -133,9 +133,9 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder }) => {
       >
         <div>Type</div>
         <div>Name</div>
-        <div>Size</div>
-        <div>Updated</div>
-        {hasActions && <div>Actions</div>}
+        <div className="text-center w-20">Size</div>
+        <div className="text-center w-24">Updated</div>
+        {hasActions && <div className="text-center w-16">Actions</div>}
       </div>
       <div className="divide-y">
         {getItemsAtCurrPath().length === 0 ? (
@@ -177,16 +177,16 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder }) => {
                   item.name
                 )}
               </div>
-              <div className="text-sm text-muted-foreground">
+              <div className="text-sm text-muted-foreground text-center w-20">
                 {item.size || "-"}
               </div>
-              <div>
+              <div className="text-center w-24">
                 <span className="text-sm text-muted-foreground">
                   {item.updatedAt}
                 </span>
               </div>
               {hasActions && (
-                <div className="flex items-center justify-end">
+                <div className="flex items-center justify-center w-16">
                   {item.type === "file" && canDeleteFile(item) && (
                     <AlertDialog>
                       <AlertDialogTrigger asChild>

--- a/src/components/communities/CommunityDetailsClient.tsx
+++ b/src/components/communities/CommunityDetailsClient.tsx
@@ -442,7 +442,7 @@ export default function CommunityDetailsClient({
                               </div>
                             </Link>
                             {/* Action Menu Area */}
-                            <div className="flex items-center ml-4">
+                            <div className="flex items-center ml-4 w-8 justify-end">
                               <ChannelsContextMenu
                                 channel={channel}
                                 onActionComplete={onActionComplete}


### PR DESCRIPTION
Fix 1 - Now the date/members part showing in one row and 3 dots are showing in other row as showing in the image. ✔️

<img width="687" height="376" alt="Screenshot_118" src="https://github.com/user-attachments/assets/0298c530-aae7-4555-8250-ce203c837ed3" />

Additional Fix 2 - The File Sharing Alignments. ✔️

<img width="1250" height="581" alt="Screenshot_124" src="https://github.com/user-attachments/assets/49b84dd8-d787-4d42-94b7-6fe0b74721f4" />
