### PR TITLE
SPRK-173: Captalized the Space Sidebar Names

### DIFF
--- a/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/SpaceSidebar.tsx
+++ b/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/SpaceSidebar.tsx
@@ -234,7 +234,7 @@ function SpaceSidebar({ space }: Props) {
 
           <SidebarGroupLabel>Other</SidebarGroupLabel>
           {spaceStaticFeatures.map((feature) => {
-            if (feature.name === "settings" && !canViewSetting) {
+            if (feature.name === "Settings" && !canViewSetting) {
               return null
             }
             return (

--- a/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/constants.ts
+++ b/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/constants.ts
@@ -1,11 +1,11 @@
 export const spaceStaticFeatures = [
   {
-    name: "settings",
+    name: "Settings",
     icon: "settings",
     slug: "settings"
   },
   {
-    name: "users",
+    name: "Users",
     icon: "users",
     slug: "users"
   }


### PR DESCRIPTION
Fixed:
- "Settings" and "Users" are now appeared with the first letter capitalized, consistent with other labels across the platform.

<img width="1101" height="644" alt="Screenshot_129" src="https://github.com/user-attachments/assets/bb8f711d-e183-40e7-b59c-ad8decb7a4ca" />
