### PR TITLE
Bug Fixed -- Blank Comment Problem

### DIFF
--- a/src/components/Dashboard/posts/post-comment-form.tsx
+++ b/src/components/Dashboard/posts/post-comment-form.tsx
@@ -38,6 +38,16 @@ const PostCommentForm: React.FC<PostCommentFormProps> = ({
 
   const handleAddComment = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+    
+    if (!commentText.current.trim()) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Please write something in the comment box before posting."
+      })
+      return
+    }
+    
     try {
       const response = await createComment(
         postId,


### PR DESCRIPTION
Blank comment is now not allowed and will give an error when we click the button if there is no text present in the comment box 