### PR TITLE
fixed typo in unpublished space card (new)

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/SpacesCard.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/SpacesCard.tsx
@@ -80,7 +80,7 @@ function SpacesCard({ space, setIsChannelMember }: Props) {
                     />
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>Darft</p>
+                    <p>Draft</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/components/communities/CommunityDetailsClient.tsx
+++ b/src/components/communities/CommunityDetailsClient.tsx
@@ -470,7 +470,7 @@ export default function CommunityDetailsClient({
                                               />
                                             </TooltipTrigger>
                                             <TooltipContent>
-                                              <p>Darft</p>
+                                              <p>Draft</p>
                                             </TooltipContent>
                                           </Tooltip>
                                         </TooltipProvider>


### PR DESCRIPTION
Issue [SPRK-211](https://etlonline.atlassian.net/browse/SPRK-211) :

# Summary

This PR fixes a minor typo in the Unpublished Space Card component where “Darft” was displayed instead of “Draft”.


## Changes Made:
Corrected the typo in the component text.
Issue Reference:
Resolves: [SPRK-211] — Typo in Unpublished Space Card

## Testing
Verified that the corrected text now displays as “Draft” in the UI.
No other functionality was affected.

**Kindly review and update.**
