### PR TITLE
Sprk 199 nonfunctional settings link in main search bar

### DIFF
--- a/src/components/Dashboard/CommandCenter/CommandCenter.tsx
+++ b/src/components/Dashboard/CommandCenter/CommandCenter.tsx
@@ -128,10 +128,6 @@ export default function CommandCenter() {
               <MessageSquare />
               <span>Chat</span>
             </CommandItem>
-            <CommandItem>
-              <Settings />
-              <span>Settings</span>
-            </CommandItem>
           </CommandGroup>
         </CommandList>
       </CommandDialog>


### PR DESCRIPTION
# Remove non-functional "Settings" quick link from main search bar

**Jira Ticket:** [SPRK-199](https://etlonline.atlassian.net/browse/SPRK-199)

## Description
The main search bar displays three quick link options with icons. However, the "Settings" quick link does not navigate to any page or trigger any action. This creates confusion for users and gives the impression of incomplete functionality.  

## Changes Made
- Removed the "Settings" quick link from the main search bar.  

## Reasoning
- Prevents user confusion caused by a non-functional link.  
- Keeps UI consistent and focused on working features.  

## Expected Result
- The "Settings" quick link will no longer be displayed until the Settings page is fully implemented.  