### PR TITLE
removed the Assign option and the separator for consistent UI

### DIFF
--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintTasks.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintTasks.tsx
@@ -227,8 +227,6 @@ function SprintTasks({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem>Assign</DropdownMenuItem>
-                <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={() => {
                     setIsTaskDropDownOpen(false)


### PR DESCRIPTION
## 🎯 Linked Issue  
[SPRK-185](https://etlonline.atlassian.net/browse/SPRK-185)  

## 📝 Description  
In **Sprint Management**, the task three-dot action menu currently displays an **“Assign”** option that is non-functional. Clicking it does not trigger any action, modal, or interface.  

Since no assignment functionality is implemented yet, the **“Assign”** option should be removed from the dropdown menu to prevent user confusion.  

---

## 🔍 Actual Result  
- “Assign” option is visible in the task menu  
- Clicking it does nothing (no modal, no action, no UI update)  

---

## ✅ Expected Result  
- “Assign” option should be **removed** from the three-dot task dropdown menu  
- Users should only see **functional options**  

Kindly review and update.
