### PR TITLE
spark-248:fixed education duration validation

### DIFF
--- a/src/components/Dashboard/profile/EditEducationModal.tsx
+++ b/src/components/Dashboard/profile/EditEducationModal.tsx
@@ -35,7 +35,7 @@ const userQualificationSchema = z
       .refine((val) => moment(val, "YYYY", true).isValid(), {
         message: "Invalid start year"
       })
-      .refine((val) => parseInt(val, 10) >= 1990, {
+      .refine((val) => moment(val, "YYYY", true).year() >= 1990, {
         message: "Start year must be 1990 or later"
       }),
 
@@ -47,9 +47,9 @@ const userQualificationSchema = z
   })
   .refine(
     (data) => {
-      const start = parseInt(data.duration_from, 10)
-      const end = parseInt(data.duration_to, 10)
-      return start < end // must be before
+      const start = moment(data.duration_from)
+      const end = moment(data.duration_to)
+      return start < end
     },
     {
       message: "Start year must be before end year",
@@ -58,9 +58,11 @@ const userQualificationSchema = z
   )
   .refine(
     (data) => {
-      const start = parseInt(data.duration_from, 10)
-      const end = parseInt(data.duration_to, 10)
-      const diff = end - start
+      const start = moment(data.duration_from)
+      const end = moment(data.duration_to)
+      const diff = end.diff(start, "years")
+      console.log("data log", { start, end, diff })
+
       return diff >= 1 && diff <= 10
     },
     {

--- a/src/components/Dashboard/profile/EditEducationModal.tsx
+++ b/src/components/Dashboard/profile/EditEducationModal.tsx
@@ -61,7 +61,6 @@ const userQualificationSchema = z
       const start = moment(data.duration_from)
       const end = moment(data.duration_to)
       const diff = end.diff(start, "years")
-      console.log("data log", { start, end, diff })
 
       return diff >= 1 && diff <= 10
     },

--- a/src/components/Dashboard/profile/EditEducationModal.tsx
+++ b/src/components/Dashboard/profile/EditEducationModal.tsx
@@ -44,9 +44,6 @@ const userQualificationSchema = z
       .refine((val) => moment(val, "YYYY", true).isValid(), {
         message: "Invalid end year"
       })
-      .refine((val) => parseInt(val, 10) <= 2034, {
-        message: "End year must be 2034 or earlier"
-      })
   })
   .refine(
     (data) => {

--- a/src/components/Dashboard/profile/EditEducationModal.tsx
+++ b/src/components/Dashboard/profile/EditEducationModal.tsx
@@ -29,26 +29,46 @@ const userQualificationSchema = z
   .object({
     degree: z.string().min(1, "Required"),
     institute: z.string().min(1, "Required"),
+
     duration_from: z
       .string()
       .refine((val) => moment(val, "YYYY", true).isValid(), {
         message: "Invalid start year"
+      })
+      .refine((val) => parseInt(val, 10) >= 1990, {
+        message: "Start year must be 1990 or later"
       }),
+
     duration_to: z
       .string()
       .refine((val) => moment(val, "YYYY", true).isValid(), {
         message: "Invalid end year"
       })
+      .refine((val) => parseInt(val, 10) <= 2034, {
+        message: "End year must be 2034 or earlier"
+      })
   })
   .refine(
     (data) => {
-      const start = moment(data.duration_from)
-      const end = moment(data.duration_to)
-      return start.isBefore(end)
+      const start = parseInt(data.duration_from, 10)
+      const end = parseInt(data.duration_to, 10)
+      return start < end // must be before
     },
     {
       message: "Start year must be before end year",
       path: ["duration_from"]
+    }
+  )
+  .refine(
+    (data) => {
+      const start = parseInt(data.duration_from, 10)
+      const end = parseInt(data.duration_to, 10)
+      const diff = end - start
+      return diff >= 1 && diff <= 10
+    },
+    {
+      message: "Degree duration must be between 1 and 10 years",
+      path: ["duration_to"]
     }
   )
 

--- a/src/components/ProfileCompletion/StepTwo.tsx
+++ b/src/components/ProfileCompletion/StepTwo.tsx
@@ -30,7 +30,7 @@ const userQualificationSchema = z
       .refine((val) => moment(val, "YYYY", true).isValid(), {
         message: "Invalid start year"
       })
-      .refine((val) => parseInt(val, 10) >= 1990, {
+      .refine((val) => moment(val, "YYYY", true).year() >= 1990, {
         message: "Start year must be 1990 or later"
       }),
 
@@ -42,8 +42,8 @@ const userQualificationSchema = z
   })
   .refine(
     (data) => {
-      const start = parseInt(data.duration_from, 10)
-      const end = parseInt(data.duration_to, 10)
+      const start = moment(data.duration_from)
+      const end = moment(data.duration_to)
       return start < end
     },
     {
@@ -53,9 +53,9 @@ const userQualificationSchema = z
   )
   .refine(
     (data) => {
-      const start = parseInt(data.duration_from, 10)
-      const end = parseInt(data.duration_to, 10)
-      const diff = end - start
+      const start = moment(data.duration_from)
+      const end = moment(data.duration_to)
+      const diff = end.diff(start, "years")
       return diff >= 1 && diff <= 10
     },
     {

--- a/src/components/ProfileCompletion/StepTwo.tsx
+++ b/src/components/ProfileCompletion/StepTwo.tsx
@@ -20,7 +20,6 @@ interface StepTwoProps {
   setUser: Dispatch<SetStateAction<SelectUser | undefined>>
 }
 
-const currentYear = moment().year()
 const userQualificationSchema = z
   .object({
     degree: z.string().min(1, "Required"),
@@ -40,15 +39,12 @@ const userQualificationSchema = z
       .refine((val) => moment(val, "YYYY", true).isValid(), {
         message: "Invalid end year"
       })
-      .refine((val) => parseInt(val, 10) <= 2034, {
-        message: "End year must be 2034 or earlier"
-      })
   })
   .refine(
     (data) => {
       const start = parseInt(data.duration_from, 10)
       const end = parseInt(data.duration_to, 10)
-      return start < end // must be before
+      return start < end
     },
     {
       message: "Start year must be before end year",

--- a/src/components/ProfileCompletion/StepTwo.tsx
+++ b/src/components/ProfileCompletion/StepTwo.tsx
@@ -25,43 +25,45 @@ const userQualificationSchema = z
   .object({
     degree: z.string().min(1, "Required"),
     institute: z.string().min(1, "Required"),
+
     duration_from: z
       .string()
-      .min(1, "Required")
-      .refine(
-        (val) => {
-          const year = parseInt(val, 10)
-          return (
-            moment(val, "YYYY", true).isValid() &&
-            year >= 1900 &&
-            year <= currentYear
-          )
-        },
-        {
-          message: `Start year must be between 1900 and ${currentYear}`
-        }
-      ),
+      .refine((val) => moment(val, "YYYY", true).isValid(), {
+        message: "Invalid start year"
+      })
+      .refine((val) => parseInt(val, 10) >= 1990, {
+        message: "Start year must be 1990 or later"
+      }),
+
     duration_to: z
       .string()
-      .min(1, "Required")
-      .refine(
-        (val) => {
-          const year = parseInt(val, 10)
-          return moment(val, "YYYY", true).isValid() && year < currentYear + 10
-        },
-        {
-          message: `End year must be less than ${currentYear + 10}`
-        }
-      )
+      .refine((val) => moment(val, "YYYY", true).isValid(), {
+        message: "Invalid end year"
+      })
+      .refine((val) => parseInt(val, 10) <= 2034, {
+        message: "End year must be 2034 or earlier"
+      })
   })
   .refine(
     (data) => {
-      const start = moment(data.duration_from)
-      const end = moment(data.duration_to)
-      return end.isAfter(start)
+      const start = parseInt(data.duration_from, 10)
+      const end = parseInt(data.duration_to, 10)
+      return start < end // must be before
     },
     {
-      message: "End year must be after start year",
+      message: "Start year must be before end year",
+      path: ["duration_from"]
+    }
+  )
+  .refine(
+    (data) => {
+      const start = parseInt(data.duration_from, 10)
+      const end = parseInt(data.duration_to, 10)
+      const diff = end - start
+      return diff >= 1 && diff <= 10
+    },
+    {
+      message: "Degree duration must be between 1 and 10 years",
       path: ["duration_to"]
     }
   )


### PR DESCRIPTION
Spark-248: Fixed Education  Duration Validation

Visit Ticket: [spark-248](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-248)

Actual Result:
The system allows saving education duration with unrealistic values (e.g., 44 years).

Expected Result:
The degree duration should be validated with a logical range (e.g., minimum 1 year, maximum 10 years). The system should prevent saving education information with invalid/unrealistic durations