### PR TITLE
Spark 323 viewer role

### DIFF
--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -351,6 +351,7 @@ export default function TaskForm({
                           className="col-span-3 !text-lg"
                           autoFocus
                           required
+                          disabled={!isAllowedAction}
                           onBlur={() => setActiveField(null)}
                         />
                       ) : (
@@ -394,6 +395,7 @@ export default function TaskForm({
                         value={field.value}
                         onChange={field.onChange}
                         image_uploading={true}
+                        editable={isAllowedAction}
                       />
                     ) : (
                       <div
@@ -456,6 +458,7 @@ export default function TaskForm({
                           <Select
                             onValueChange={field.onChange}
                             value={field.value}
+                            disabled={!isAllowedAction}
                           >
                             <SelectTrigger
                               id="status_id"
@@ -512,6 +515,7 @@ export default function TaskForm({
                           <MultiSelect
                             options={assigneeOptions}
                             selected={selectedAssignee}
+                            disabled={!isAllowedAction}
                             onChange={(newselected) => {
                               if (newselected.length === 0) {
                                 setSelectedAssignee([
@@ -575,6 +579,7 @@ export default function TaskForm({
                           <MultiSelect
                             options={assignorOptions}
                             selected={selectedAssignor}
+                            disabled={!isAllowedAction}
                             onChange={(newselected) => {
                               const latestSelected =
                                 newselected?.[newselected.length - 1]
@@ -631,6 +636,7 @@ export default function TaskForm({
                           <Select
                             value={field.value}
                             onValueChange={field.onChange}
+                            disabled={!isAllowedAction}
                           >
                             <SelectTrigger
                               id="task_priority"
@@ -694,6 +700,7 @@ export default function TaskForm({
                           <Select
                             value={field.value}
                             onValueChange={field.onChange}
+                            disabled={!isAllowedAction}
                           >
                             <SelectTrigger
                               id="task_type"
@@ -752,6 +759,7 @@ export default function TaskForm({
                       render={({ field }) =>
                         activeField === "points" ? (
                           <Input
+                            disabled={!isAllowedAction}
                             id="story_points"
                             type="number"
                             min={0}

--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -41,13 +41,15 @@ interface RichTextEditorProps {
   value?: string
   onChange?: (content: string) => void
   image_uploading?: boolean
+  editable?: boolean
 }
 
 const limit = 1000
 export default function RichTextEditor({
   value,
   onChange,
-  image_uploading
+  image_uploading,
+  editable
 }: RichTextEditorProps) {
   const [linkUrl, setLinkUrl] = useState("")
   const [showLinkInput, setShowLinkInput] = useState(false)
@@ -76,6 +78,7 @@ export default function RichTextEditor({
       })
     ],
     content: value,
+    editable,
     editorProps: {
       attributes: {
         class:

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -29,6 +29,7 @@ interface MultiSelectProps {
   className?: string
   loading?: boolean
   shouldFilter?: boolean
+  disabled?: boolean
 }
 
 export default function MultiSelect({
@@ -39,7 +40,8 @@ export default function MultiSelect({
   placeholder = "Select options",
   className,
   loading = false,
-  shouldFilter = true
+  shouldFilter = true,
+  disabled = false
 }: MultiSelectProps) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
@@ -96,6 +98,7 @@ export default function MultiSelect({
           <Button
             variant="outline"
             className={className ?? "w-full justify-start "}
+            disabled={disabled}
           >
             {placeholder}
           </Button>


### PR DESCRIPTION
Spark-323: task form disable for viewers

Visit Ticket:[Spark-323](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-323)

### Actual Result:

A Success message is displayed.
The task detail gets updated even though the Update button is not shown for the Viewer role.

### Expected Result:

Viewers should not be able to update task details in any way.
Pressing Enter in the Title field should not trigger a save action for Viewer role.