### PR TITLE
SPRK -306 add char limit of 50 in gorup chat

### DIFF
--- a/src/components/Dashboard/Chat/components/CreateNewChat.tsx
+++ b/src/components/Dashboard/Chat/components/CreateNewChat.tsx
@@ -118,6 +118,9 @@ const CreateNewChat = () => {
         if (groupName.trim() === "") {
           setGroupNameError("Group name is required.")
           return
+        } else if (groupName.trim().length > 50) {
+          setGroupNameError("Group name must be 50 characters or less.")
+          return
         } else {
           setGroupNameError("")
         }
@@ -160,11 +163,11 @@ const CreateNewChat = () => {
           })
         }
       }
-    } finally {
       setSelectedContacts([])
       setGroupName("")
       setIsGroupChat(false)
       setDialogOpen(false)
+    } finally {
       setIsCreatingChat(false)
     }
   }


### PR DESCRIPTION
[SPRK -306](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-306)

Title: In chat while creating group you can take group name as long as you want which then creates UI issues

Issue: Select Contacts and add 2 or more members and in place of group name you can add it as long as you want 

Resolved : now user can add 50 char into the name of group 