### PR TITLE
SPRK-345 image disapear is fixed now

### DIFF
--- a/src/db/data-access/post/query.ts
+++ b/src/db/data-access/post/query.ts
@@ -168,7 +168,12 @@ export const GetPosts = async (filters: PostQueryFilters = {}) => {
     ]
 
     if (globalPostsOnly) {
-      whereClauses.push(isNull(postsTable.entity_id))
+      whereClauses.push(
+        or(
+          isNull(postsTable.entity_id),
+          eq(postsTable.entity_id, "")
+        ) as SQL<unknown>
+      )
     } else if (entityId) {
       whereClauses.push(eq(postsTable.entity_id, entityId))
     } else {


### PR DESCRIPTION
[SPRK-345](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-345)

This PR addresses a bug where image posts, which also contain text, were not visible after a page refresh.

The root cause was a mismatch between how the database stored the post's entity ID and how the query checked for it. The database was saving an empty string ('') for the entity_id of these posts, while the GetPosts query was only checking for a NULL value using isNull().

This change updates the query to correctly account for both scenarios, ensuring that posts with a missing entity_id (either NULL or an empty string) are retrieved as expected.

Technical Changes

    Modified the GetPosts function to check for postsTable.entity_id being either NULL or an empty string.

    The whereClauses now uses an or() condition to combine isNull(postsTable.entity_id) and eq(postsTable.entity_id, '').

How to Test

    Create a new post that includes both an image and some text.

    Refresh the page.

    Verify that the post remains visible after the refresh.