### PR TITLE
spark-331-self-user-in-space-chat

### DIFF
--- a/src/components/Dashboard/Chat/components/CreateNewChat.tsx
+++ b/src/components/Dashboard/Chat/components/CreateNewChat.tsx
@@ -54,12 +54,14 @@ const CreateNewChat = () => {
   const isSpacePage = space_slug ? true : false
 
   const getOptionsFromUserList = (users: SelectUser[]) => {
-    return users.map((user) => {
-      return {
-        label: `${user.first_name} ${user.last_name}`,
-        value: user.unique_id
-      }
-    })
+    return users
+      .filter((user) => user.unique_id !== authUser?.unique_id)
+      .map((user) => {
+        return {
+          label: `${user.first_name} ${user.last_name}`,
+          value: user.unique_id
+        }
+      })
   }
 
   const getUserList = async (filters: ChatContactFilters) => {


### PR DESCRIPTION
[spark-331](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-331)

**### Steps to Reproduce:**

Go to Space > Chat.
Click Create Chat.
Open the contact selection dropdown.
Notice that the logged-in user is also shown in the list.

**### Actual Result:**
While creating a Space chat, the logged-in user also appears in the contact dropdown list.
This is unnecessary because:
In one-to-one chat, a user should not be able to select themselves as a contact.
In group chat, the user is automatically added as a member, so there is no need to display them in the list.

**### Expected Result:**
The logged-in user should not appear in the contact dropdown while creating a Space chat.