### PR TITLE
spark-348:fixed breadcrumb issuse

### DIFF
--- a/src/components/UserListAndInvite/UserList.tsx
+++ b/src/components/UserListAndInvite/UserList.tsx
@@ -419,9 +419,11 @@ export default function ChannelUserList({
         <div className="flex items-center space-x-2">
           <Link
             href={
-              entityType === "channel"
-                ? `/channels/${(entity as SelectChannel).channel_slug}/spaces`
-                : `/channels/${(entity as SelectSpace).channel?.channel_slug}/spaces/${(entity as SelectSpace).space_slug}`
+              entityType === "community"
+                ? `/communities/${(entity as CommunityDetailData).slug}`
+                : entityType === "channel"
+                  ? `/channels/${(entity as SelectChannel).channel_slug}/spaces`
+                  : `/channels/${(entity as SelectSpace).channel?.channel_slug}/spaces/${(entity as SelectSpace).space_slug}`
             }
           >
             <h1 className="text-2xl font-bold">{entityName}</h1>


### PR DESCRIPTION
[spark-348](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-348)

**Description**
On the Community User Management page, when a user clicks on the Community name in the breadcrumb navigation, it redirects to a 404 Page Not Found instead of the respective Community details page.

**Steps to Reproduce:**

1. Login to the application.
2. Navigate to a Community.
3. Open the User Management section of that Community.
4. In the breadcrumb navigation, click on the Community name.

**Actual Result:**
Clicking on the Community name redirects the user to a 404 Page.

**Expected Result:**
Clicking on the Community name in the breadcrumb should redirect the user to the Community Details page instead of showing a 404 error.