### PR TITLE
spark-310:fixed task created on pressing enter key

### DIFF
--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -339,7 +339,12 @@ export default function TaskForm({
 
   return (
     <>
-      <form onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.preventDefault()
+        }}
+      >
         <div className="flex flex-col md:flex-row gap-2 ">
           {/* Main content area (left side) */}
           <div className="flex-1 px-2">


### PR DESCRIPTION
[spark-310](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-310)
**Issue**
While creating a new backlog task, pressing Enter in the title input field (if priority and issue type are already selected) automatically saves the task. This behavior bypasses the intended workflow where the task should only be created after explicitly clicking the "Create Task" button.

**Fix**
1. Disabled form submission via the Enter key in the task creation form.
2. Ensured task creation is only triggered by explicitly clicking the "Create Task" button.

**How to Test**
1. Go to the backlog section.
2. Click on Create New Task.
3. Enter a title in the title field.
4. Select Priority and Issue Type.
5. Press Enter.

