### PR TITLE
SPRK-341 added "game/playable development" option in interest

### DIFF
--- a/src/db/seeds/InterestSeedList.ts
+++ b/src/db/seeds/InterestSeedList.ts
@@ -9,7 +9,7 @@ export const interestSeedList = [
   "UI/UX Design", // 7
   "Cloud Computing", // 8
   "DevOps", // 9
-  "Game Development", // 10
+  "Game/Playable Development", // 10
   "Blockchain", // 11
   "Internet of Things (IoT)", // 12
   "Augmented Reality", // 13


### PR DESCRIPTION
Updated the interest name "Game Development" to "Game/Playable Development" in the Interests list.. Existing user profiles linked to this interest remain unaffected, as only the display name has been updated.