### PR TITLE
SPRK-252: Fix profile image overflow in connections

### DIFF
--- a/src/components/Dashboard/NotificationItem/NotifictionItem.tsx
+++ b/src/components/Dashboard/NotificationItem/NotifictionItem.tsx
@@ -34,8 +34,8 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
     <div className="flex items-center justify-between p-2 border-b last:border-b-0 max-[622px]:flex-col max-[622px]:items-start max-[622px]:space-x-0 max-[622px]:space-y-4">
       <div className="grid grid-cols-[48px,1fr] gap-3 items-start w-full">
         {/* Avatar column (fixed 48px) */}
-        <div className="relative">
-          <Avatar className="h-12 w-12">
+        <div className="relative h-12 w-12 ">
+          <Avatar>
             <AvatarImage
               src={activity.icon || ""}
               alt={activity.title}

--- a/src/components/Dashboard/profile/ProfileActivityItem.tsx
+++ b/src/components/Dashboard/profile/ProfileActivityItem.tsx
@@ -45,7 +45,7 @@ const ProfileActivityItem: React.FC<ProfileActivityItemProps> = ({
         <Avatar className="h-12 w-12">
           <Link href={size === "sm" ? "#" : `/profile/${otherUser.unique_id}`}>
             <AvatarImage
-              className="rounded-full"
+              className="h-[100%] w-[100%] object-cover rounded-full"
               src={otherUser.profile_url as string}
               alt={name}
             />


### PR DESCRIPTION
[Sprk-252](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-252)

**Description**
1- Open Profile.
2- Change profile picture and select a long one.
3- Now send request to your other account.
4- Open that account and go the notification section you  can see there the picture moving out of its intended position also you can see it in the section where you see the connection requests