### PR TITLE
SPRK-354:fixed education validation issue

### DIFF
--- a/src/components/Dashboard/profile/EditEducationModal.tsx
+++ b/src/components/Dashboard/profile/EditEducationModal.tsx
@@ -30,8 +30,8 @@ interface Props {
 
 const userQualificationSchema = z
   .object({
-    degree: z.string().min(1, "Required"),
-    institute: z.string().min(1, "Required"),
+    degree: z.string().min(1, "Required").max(100, "Maximum 100 characters"),
+    institute: z.string().min(1, "Required").max(100, "Maximum 100 characters"),
 
     duration_from: z
       .string()
@@ -40,6 +40,9 @@ const userQualificationSchema = z
       })
       .refine((val) => moment(val, "YYYY", true).year() >= 1990, {
         message: "Start year must be 1990 or later"
+      })
+      .refine((val) => moment(val, "YYYY", true).year() <= moment().year(), {
+        message: "Start Year cannot be in the future"
       }),
 
     duration_to: z

--- a/src/components/Dashboard/profile/ProfileScreen.tsx
+++ b/src/components/Dashboard/profile/ProfileScreen.tsx
@@ -449,10 +449,12 @@ export default function ProfileScreen({
               </CardHeader>
               <CardContent>
                 <div className="flex items-start gap-3">
-                  <GraduationCap className="h-6 w-6 text-muted-foreground mt-0.5" />
-                  <div>
-                    <h4 className="font-medium">{profile?.institute}</h4>
-                    <p className="text-sm text-muted-foreground">
+                  <GraduationCap className="h-6 w-6 text-muted-foreground mt-0.5 flex-shrink-0" />
+                  <div className="min-w-0 ">
+                    <h4 className="font-medium truncate">
+                      {profile?.institute}
+                    </h4>
+                    <p className="text-sm text-muted-foreground truncate">
                       {profile?.degree}
                     </p>
                     <div className="flex items-center gap-1 mt-1">

--- a/src/components/ProfileCompletion/StepTwo.tsx
+++ b/src/components/ProfileCompletion/StepTwo.tsx
@@ -22,8 +22,8 @@ interface StepTwoProps {
 
 const userQualificationSchema = z
   .object({
-    degree: z.string().min(1, "Required"),
-    institute: z.string().min(1, "Required"),
+    degree: z.string().min(1, "Required").max(100, "Maximum 100 characters"),
+    institute: z.string().min(1, "Required").max(100, "Maximum 100 characters"),
 
     duration_from: z
       .string()
@@ -32,6 +32,9 @@ const userQualificationSchema = z
       })
       .refine((val) => moment(val, "YYYY", true).year() >= 1990, {
         message: "Start year must be 1990 or later"
+      })
+      .refine((val) => moment(val, "YYYY", true).year() <= moment().year(), {
+        message: "Start Year cannot be in the future"
       }),
 
     duration_to: z


### PR DESCRIPTION
[SPRK-354](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-354)

**Description**

The following issues are observed in the Profile → Education section:

1. **Missing Character Limit for Degree & Institution Name:**

- Currently, there is no limit for entering the Degree Name and Institution Name.
- Users can enter excessively long values which break the layout.
- **Expected Result**: A reasonable character limit (e.g., 50–100 characters) should be set.

2. **Card Layout Handling for Long Text:**

- Even with character limits, the text should be displayed gracefully inside the card.
- **Expected Result:** Long values should wrap or truncate with ellipsis (…) to maintain proper UI alignment.

3. **Future Year Allowed in Start Year:**

- The Start Year field currently allows entering future years, which is invalid for educational history.
- **Expected Result**: The Start Year should not exceed the current year. If entered, an error message like “Start Year cannot be in the future” should be displayed.