### PR TITLE
SPRK-223:add tooltip on lock icon

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/SpacesCard.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/SpacesCard.tsx
@@ -59,7 +59,16 @@ function SpacesCard({ space, setIsChannelMember }: Props) {
           <CardTitle className="text-xl flex items-center gap-1">
             {space.space_name}
             {space.space_type === "private" && (
-              <Lock className="text-muted-foreground" height={14} />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Lock className="text-muted-foreground" height={14} />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p className="text-sm">Private</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
 
             {canUpdateSpace &&


### PR DESCRIPTION
[SPRK-223](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-223)

**Description**

When hovering over the "Lock" icon in a private space, no tooltip is displayed. It should show "Private", similar to how hovering over the "Tick" icon displays "Published".

**Steps to Reproduce:**

1. Navigate to any private space.
2. Hover the mouse over the "Lock" icon next to the space name.

**Expected Result:** Tooltip "Private" should appear on hover