### PR TITLE
SPRK-241:view community usrs

### DIFF
--- a/src/components/communities/CommunityDetailsClient.tsx
+++ b/src/components/communities/CommunityDetailsClient.tsx
@@ -240,6 +240,8 @@ export default function CommunityDetailsClient({
     }
   }
 
+  const encodedCommunitySlug = encodeURIComponent(community.slug)
+
   return (
     <div className="min-h-screen bg-background relative">
       {/* Added relative for the overlay positioning */}
@@ -582,7 +584,12 @@ export default function CommunityDetailsClient({
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Users className="h-4 w-4 text-muted-foreground" />
-                    <span className="text-xs lg:text-sm">Total Members</span>
+                    <Link
+                      href={`/communities/${encodedCommunitySlug}/users`}
+                      className="text-xs lg:text-sm hover:underline hover:decoration-white"
+                    >
+                      Members
+                    </Link>
                   </div>
                   <span className="font-bold text-sm lg:text-base">
                     {community?.totalMembers?.toLocaleString() ?? 0}


### PR DESCRIPTION
[SPRK-241](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-241)

**Description**

Currently, community users cannot be viewed from inside the community. The only way to see members is by navigating to the Communities list and accessing the three-dots menu. Inside the community, only the total member count is displayed in the detail view and on the community card in the main listing page, but there is no way to see the list of actual members. This creates unnecessary navigation steps and reduces usability.

**Steps to Reproduce:**

1. Open any Community.
2. Navigate to the Community detail view.
3. Observe that only the total member count is displayed, with no option to view actual users.

**Actual Result:**

1. Only the total member count is visible.
2. No option exists to view or manage users from inside the Community.
3. To view members, users must go back to the Communities list and use the three-dots menu.

**Expected Result:**
Users should be able to:

1. View the actual list of Community members directly from inside the Community.
2. Access a User Management or View Members option within the Community page (e.g., through Community Stats or a dedicated section)..

**Fix Implemented:**

1. Made the "Total Members" section clickable in the Community detail view.
2. On hover, it now shows an underline to indicate it is interactive.
3. When clicked, users are redirected to the Community Members page, where they can view the complete list of members.

