### PR TITLE
SPRK-383 Fix Application Error on Communities Action Menu and Restore Persona Visibility on User Profiles

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,7 @@ import ThemeProvider from "../components/ThemeProvider/ThemeProvider"
 import { Toaster } from "../components/ui/toaster"
 import { dark } from "@clerk/themes"
 import AuthInitializer from "../services/auth/AuthInitializer"
-import NotificationProvider from "../services/notifications/NotificationProvider"
-
+import { ScreenOverlayProvider } from "../hooks/useScreenOverlay"
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
   variable: "--font-geist-sans",
@@ -43,7 +42,7 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <Toaster />
-            {children}
+            <ScreenOverlayProvider>{children}</ScreenOverlayProvider>
           </ThemeProvider>
         </body>
       </html>

--- a/src/components/Dashboard/Sidebar.tsx/nav-user.tsx
+++ b/src/components/Dashboard/Sidebar.tsx/nav-user.tsx
@@ -30,13 +30,7 @@ export default function NavUser() {
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
 
-  const { manualLogout, loading } = useOnLogout()
-
-  useEffect(() => {
-    if (!loading) {
-      setIsDropdownOpen(false)
-    }
-  }, [loading])
+  const { manualLogout } = useOnLogout()
 
   return (
     <SidebarMenu>
@@ -123,7 +117,6 @@ export default function NavUser() {
               className="cursor-pointer"
               onSelect={(e) => e.preventDefault()}
               onClick={() => manualLogout()}
-              loading={loading}
             >
               <LogOut />
               Sign out

--- a/src/components/common/ScreenOverlay.tsx
+++ b/src/components/common/ScreenOverlay.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+import Loader from "./Loader/Loader"
+import { LoaderSizes } from "./types/loader-types"
+
+function ScreenOverlay() {
+  return (
+    <div className="absolute h-screen inset-0 bg-background/95 backdrop-blur-sm z-50 flex flex-col items-center justify-center p-4 text-center overflow-hidden">
+      <Loader size={LoaderSizes.xl} />
+    </div>
+  )
+}
+
+export default ScreenOverlay

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -81,9 +81,8 @@ const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
     inset?: boolean
-    loading?: boolean
   }
->(({ className, inset, loading, disabled, children, ...props }, ref) => (
+>(({ className, inset, disabled, children, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
@@ -91,11 +90,10 @@ const DropdownMenuItem = React.forwardRef<
       inset && "pl-8",
       className
     )}
-    disabled={disabled || loading}
+    disabled={disabled}
     {...props}
   >
     {children}
-    {loading ? <Loader size={LoaderSizes.sm} /> : null}
   </DropdownMenuPrimitive.Item>
 ))
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName

--- a/src/db/data-access/user/query.ts
+++ b/src/db/data-access/user/query.ts
@@ -56,7 +56,12 @@ export async function SelectUserByUniqueId(unique_id: string) {
   return await db.query.usersTable.findFirst({
     where: eq(usersTable.unique_id, unique_id),
     with: {
-      profile: true
+      profile: true,
+      roles: {
+        with: {
+          role: true
+        }
+      }
     }
   })
 }

--- a/src/hooks/useScreenOverlay.tsx
+++ b/src/hooks/useScreenOverlay.tsx
@@ -1,0 +1,35 @@
+"use client"
+import React, { createContext, useContext, useState, ReactNode } from "react"
+import ScreenOverlay from "../components/common/ScreenOverlay"
+
+type ScreenOverlayContextType = {
+  showOverlay: () => void
+  hideOverlay: () => void
+}
+
+const ScreenOverlayContext = createContext<ScreenOverlayContextType | null>(
+  null
+)
+
+export function ScreenOverlayProvider({ children }: { children: ReactNode }) {
+  const [visible, setVisible] = useState(false)
+
+  const showOverlay = () => setVisible(true)
+  const hideOverlay = () => setVisible(false)
+
+  return (
+    <ScreenOverlayContext.Provider value={{ showOverlay, hideOverlay }}>
+      {children}
+      {visible && <ScreenOverlay />}
+    </ScreenOverlayContext.Provider>
+  )
+}
+
+export function useScreenOverlay() {
+  const context = useContext(ScreenOverlayContext)
+  if (!context)
+    throw new Error(
+      "useScreenOverlay must be used within a ScreenOverlayProvider"
+    )
+  return context
+}

--- a/src/hooks/useSignOut.ts
+++ b/src/hooks/useSignOut.ts
@@ -1,10 +1,11 @@
 import { useClerk } from "@clerk/nextjs"
 import { getBeamsClient } from "../services/notifications/BeamClient"
 import { useState } from "react"
+import { useScreenOverlay } from "./useScreenOverlay"
 
 export function useOnLogout() {
   const { signOut } = useClerk()
-  const [loading, setLoading] = useState(false)
+  const { showOverlay, hideOverlay } = useScreenOverlay()
 
   const beamClient = getBeamsClient()
 
@@ -16,13 +17,13 @@ export function useOnLogout() {
   // manual logout
   async function manualLogout() {
     try {
-      setLoading(true)
+      showOverlay()
       await cleanup()
       await signOut()
     } finally {
-      setLoading(false)
+      hideOverlay()
     }
   }
 
-  return { manualLogout, loading }
+  return { manualLogout }
 }


### PR DESCRIPTION
- Overview

This PR resolves two issues identified in the Communities and User Profile modules:

1. Communities Action Menu Error:
    Clicking the three dots (⋮) action menu on the Communities main listing page caused a client-side exception, redirecting users      to an Application Error page.

2. Persona Visibility Issue:
The persona information was not appearing correctly on other users’ profile pages.

**Testing Steps**

1. Navigate to Communities → Main Listing Page.
2. Click the three dots (⋮) for any listed community — the action dropdown should now open without errors. 
3. Visit any other user’s profile — confirm the persona is now visible.

**Expected Result**
- The Communities action menu opens seamlessly without triggering an application error.
- Persona information displays correctly on all user profiles.