### PR TITLE
SPRK-373 fix the subject and heading of the mail now it will be same

### DIFF
--- a/src/db/seeds/EmailTemplatesSeed.ts
+++ b/src/db/seeds/EmailTemplatesSeed.ts
@@ -32,7 +32,7 @@ const templatesToSeed: NewEmailTemplate[] = [
   },
   {
     name: "project_invite",
-    subject: "You're invited to join a project",
+    subject: "You've Been Added to a Project!",
     body: loadTemplate("project_invite.html")
   },
   {

--- a/src/services/notify/project/project.ts
+++ b/src/services/notify/project/project.ts
@@ -19,7 +19,7 @@ export async function createProjectInviteNotification(
   const linkUrl = createAbsoluteUrl(`/project/${project?.data?.id}/board`)
   const payload = {
     logoUrl: logoUrl,
-    subject: "You're invited to join a project",
+    subject: "You've Been Added to a Project!",
     projectName: project?.data?.project_name,
     inviterName: `${authUser.first_name} ${authUser.last_name}`,
     ctaLink: linkUrl


### PR DESCRIPTION
Here is a clear and concise description for your GitHub Pull Request (PR) based on the bug report and your fix.

PR Description

Fix: Correct Email Subject for User Project Addition 📧

This PR resolves a discrepancy between the email subject and the body content when a user is directly added to a project.

🎯 Problem

When a user was added to a project, the email subject incorrectly stated: "You're invited to join a project"

This subject implies that the user still needs to accept an invitation, contradicting the email body which correctly stated: "You have been added to project [Project Name]"

This mismatch caused confusion, as the user was already active in the project without needing further action.

✅ Solution

The email template logic has been updated to ensure the subject line accurately reflects the action taken.

The new email subject will now be:

"You're invited to join a project"

This change ensures clarity and consistency for users receiving project notifications.