### PR TITLE
SPRK-224:fix profile ui and validation issuse

### DIFF
--- a/src/components/ProfileCompletion/StepOne.tsx
+++ b/src/components/ProfileCompletion/StepOne.tsx
@@ -250,7 +250,7 @@ export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
               disabled={loading}
             >
               <Upload className="mr-2 h-4 w-4" />
-              Upload Picture
+              {currentImageUrl ? "Change Picture" : "Upload Picture"}
             </Button>
             <input
               type="file"

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -62,19 +62,14 @@ export default function MultiSelect({
     }
   }
 
-  const allValues = options.map((o) => o.value)
-  const allSelected = allValues.every((val) => selectedValues.includes(val))
-  const noneSelected = allValues.every((val) => !selectedValues.includes(val))
+  const hasAnySelected = selectedValues.length > 0
 
-  const toggleAll = () => {
-    if (allSelected) {
-      onChange(selected.filter((s) => !allValues.includes(s.value)))
-    } else {
-      const mergedMap = new Map<string, MultiSelectOption>()
-      selected.forEach((s) => mergedMap.set(s.value, s))
-      options.forEach((o) => mergedMap.set(o.value, o))
-      onChange(Array.from(mergedMap.values()))
-    }
+  const selectAll = () => {
+    onChange([...options])
+  }
+
+  const deselectAll = () => {
+    onChange([])
   }
 
   return (
@@ -116,34 +111,43 @@ export default function MultiSelect({
                 <Loader />
               </div>
             ) : null}
-
-            <CommandEmpty>No results found.</CommandEmpty>
-
-            <CommandGroup>
-              <CommandItem
-                onSelect={toggleAll}
-                className="text-muted-foreground"
-              >
-                <Checkbox
-                  checked={allSelected && !noneSelected}
-                  className="mr-2"
-                />
-                {allSelected ? "Deselect All" : "Select All"}
-              </CommandItem>
-              {options.map((option) => (
-                <CommandItem
-                  key={option.value}
-                  onSelect={() => toggleOption(option)}
-                >
-                  <Checkbox
-                    checked={selectedValues.includes(option.value)}
-                    onCheckedChange={() => toggleOption(option)}
-                    className="mr-2"
-                  />
-                  {option.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
+            {!loading && options.length === 0 && query.length > 0 && (
+              <CommandEmpty>No results found.</CommandEmpty>
+            )}
+            {options.length > 0 && (
+              <CommandGroup>
+                {hasAnySelected ? (
+                  <CommandItem
+                    onSelect={deselectAll}
+                    className="text-muted-foreground"
+                  >
+                    <Checkbox checked={hasAnySelected} className="mr-2" />
+                    Deselect All
+                  </CommandItem>
+                ) : (
+                  <CommandItem
+                    onSelect={selectAll}
+                    className="text-muted-foreground"
+                  >
+                    <Checkbox checked={false} className="mr-2" />
+                    Select All
+                  </CommandItem>
+                )}
+                {options.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    onSelect={() => toggleOption(option)}
+                  >
+                    <Checkbox
+                      checked={selectedValues.includes(option.value)}
+                      onCheckedChange={() => toggleOption(option)}
+                      className="mr-2"
+                    />
+                    {option.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
           </Command>
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
[SPRK-224](https://etlonline.atlassian.net/jira/software/projects/SPRK/boards/35?selectedIssue=SPRK-224)

During the profile creation process, multiple UI and validation issues are observed that affect user experience and consistency:

**Profile Picture Upload Button:**
After successfully uploading a profile picture, the “Upload Picture” button still shows. The text should update (e.g., “Change Picture” or “Update Picture”) to reflect that a picture has already been uploaded.

**Education Start Year Validation:**
While entering education details, if the user inputs correct data in the "Start Year" field, the error message does not disappear in real-time. The system should validate dynamically and remove the error immediately once valid input is provided.

**Social Media Links Success Message:**
When no social media links are added, a misleading success toast appears stating “Social media links updated successfully.” The message should only appear if links are actually provided and saved.

**Skills & Interests Search Bar:**

- No error validation appears when a search yields no results (should display “No results found” or similar).
- The "Deselect" option appears even when no options are selected, which is confusing for the user.

**Expected Result:**

1. Profile picture upload button should update its label after upload.
2. Error messages in education fields should disappear in real-time upon valid input.
3. Success messages for social media links should display only when actual data is saved.
4. Search bar for skills & interests should display proper “no results” validation and only show “Deselect” when there are selected items.

**Point 2 and 3 are already fixed.**

Point 2 was resolved in spark-377.
Point 3 is already working as expected.