### PR TITLE
SPRK-300 fix the ui of space heading  and the join button

### DIFF
--- a/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/SpaceSidebar.tsx
+++ b/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/SpaceSidebar.tsx
@@ -167,7 +167,7 @@ function SpaceSidebar({ space }: Props) {
     <SidebarGroup className="p-0">
       <SidebarGroupContent>
         <SidebarMenu>
-          {/* Space Name */}
+          {/* 1. Space Name (Cleaned up) */}
           <SidebarMenuButton
             size={"lg"}
             className="hover:bg-transparent hover:text-sidebar-foreground"
@@ -179,53 +179,63 @@ function SpaceSidebar({ space }: Props) {
               </div>
               {/* Content */}
               <div className="flex-1 min-w-0 ">
-                <div className="flex items-center justify-between gap-2 mb-1">
-                  <span className="truncate font-semibold text-sm">
-                    {space.space_name}
-                  </span>
-                  {!isSuperAdmin && (
-                    <>
-                      {isLoading ? (
-                        <span className="text-xs text-gray-500 border border-gray-500 rounded-md px-2 py-1">
-                          Loading...
-                        </span>
-                      ) : isSpaceMember ? (
-                        <span
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            if (!leaveLoading) handleLeaveSpace()
-                          }}
-                          className={`leave-btn${leaveLoading ? " disabled" : ""}`}
-                        >
-                          <LogOut className="mr-2 h-3 w-3" />
-                          {leaveLoading ? "Leaving..." : "Leave"}
-                        </span>
-                      ) : (
-                        <span
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            if (!joinLoading) handleJoinSpace()
-                          }}
-                          className={`inline-flex items-center rounded-md border  bg-background px-3 py-1 text-xs font-medium ring-offset-background transition-colors ${
-                            joinLoading
-                              ? "text-gray-500 cursor-not-allowed opacity-50"
-                              : " hover:bg-primary hover:text-primary-foreground cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                          }`}
-                        >
-                          <PlusCircle className="mr-2 h-3 w-3" />
-                          {joinLoading ? "Joining..." : "Join"}
-                        </span>
-                      )}
-                    </>
-                  )}
-                </div>
-                <span className="truncate flex items-center gap-1 text-xs hover:text-sidebar-accent-foreground">
-                  <Users className="h-3 w-3" />
-                  {space.users?.length || 0} members
+                {/* Cleaned up space name */}
+                <span className="font-semibold text-sm">
+                  {space.space_name}
                 </span>
               </div>
             </div>
           </SidebarMenuButton>
+
+          {/* 2. NEW DEDICATED BUTTON/INFO AREA */}
+          <div className="px-4 py-2 flex items-center justify-between border-b border-sidebar-border/50">
+            {/* Member Count */}
+            <span className="truncate flex items-center gap-1 text-xs text-sidebar-foreground/70">
+              <Users className="h-3 w-3" />
+              {space.users?.length || 0} members
+            </span>
+
+            {/* Join/Leave Button */}
+            {!isSuperAdmin && (
+              <>
+                {isLoading ? (
+                  <span className="text-xs text-gray-500 rounded-md">
+                    Loading...
+                  </span>
+                ) : isSpaceMember ? (
+                  <span
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      if (!leaveLoading) handleLeaveSpace()
+                    }}
+                    className={`leave-btn flex items-center text-xs font-medium cursor-pointer rounded-md px-2 py-1 transition-colors hover:bg-red-500/10 hover:text-red-500 ${
+                      leaveLoading
+                        ? "text-gray-500 cursor-not-allowed opacity-50"
+                        : "text-red-400"
+                    }`}
+                  >
+                    <LogOut className="mr-1 h-3 w-3" />
+                    {leaveLoading ? "Leaving..." : "Leave"}
+                  </span>
+                ) : (
+                  <span
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      if (!joinLoading) handleJoinSpace()
+                    }}
+                    className={`inline-flex items-center rounded-md border border-sidebar-accent bg-sidebar-accent/10 px-3 py-1 text-xs font-medium ring-offset-background transition-colors ${
+                      joinLoading
+                        ? "text-gray-500 cursor-not-allowed opacity-50"
+                        : " hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    }`}
+                  >
+                    <PlusCircle className="mr-1 h-3 w-3" />
+                    {joinLoading ? "Joining..." : "Join"}
+                  </span>
+                )}
+              </>
+            )}
+          </div>
 
           {/* space overview */}
           <Link

--- a/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/SpaceSidebar.tsx
+++ b/src/app/(dashboard)/channels/[channel_slug]/spaces/[space_slug]/(space-layout)/components/SpaceSidebar.tsx
@@ -186,55 +186,56 @@ function SpaceSidebar({ space }: Props) {
               </div>
             </div>
           </SidebarMenuButton>
+          {/* Responsive Member Info & Action Area */}
+          <div className="px-4 py-2 border-b border-sidebar-border/50">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              {/* Member Count - allows shrinking */}
+              <span className="flex items-center gap-1 text-xs text-sidebar-foreground/70">
+                <Users className="h-3 w-3 flex-shrink-0" />
+                <span>{space.users?.length || 0} members</span>
+              </span>
 
-          {/* 2. NEW DEDICATED BUTTON/INFO AREA */}
-          <div className="px-4 py-2 flex items-center justify-between border-b border-sidebar-border/50">
-            {/* Member Count */}
-            <span className="truncate flex items-center gap-1 text-xs text-sidebar-foreground/70">
-              <Users className="h-3 w-3" />
-              {space.users?.length || 0} members
-            </span>
-
-            {/* Join/Leave Button */}
-            {!isSuperAdmin && (
-              <>
-                {isLoading ? (
-                  <span className="text-xs text-gray-500 rounded-md">
-                    Loading...
-                  </span>
-                ) : isSpaceMember ? (
-                  <span
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (!leaveLoading) handleLeaveSpace()
-                    }}
-                    className={`leave-btn flex items-center text-xs font-medium cursor-pointer rounded-md px-2 py-1 transition-colors hover:bg-red-500/10 hover:text-red-500 ${
-                      leaveLoading
-                        ? "text-gray-500 cursor-not-allowed opacity-50"
-                        : "text-red-400"
-                    }`}
-                  >
-                    <LogOut className="mr-1 h-3 w-3" />
-                    {leaveLoading ? "Leaving..." : "Leave"}
-                  </span>
-                ) : (
-                  <span
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (!joinLoading) handleJoinSpace()
-                    }}
-                    className={`inline-flex items-center rounded-md border border-sidebar-accent bg-sidebar-accent/10 px-3 py-1 text-xs font-medium ring-offset-background transition-colors ${
-                      joinLoading
-                        ? "text-gray-500 cursor-not-allowed opacity-50"
-                        : " hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                    }`}
-                  >
-                    <PlusCircle className="mr-1 h-3 w-3" />
-                    {joinLoading ? "Joining..." : "Join"}
-                  </span>
-                )}
-              </>
-            )}
+              {/* Join/Leave Button - prevents shrinking */}
+              {!isSuperAdmin && (
+                <div className="flex-shrink-0">
+                  {isLoading ? (
+                    <span className="text-xs text-gray-500 rounded-md whitespace-nowrap">
+                      Loading...
+                    </span>
+                  ) : isSpaceMember ? (
+                    <span
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (!leaveLoading) handleLeaveSpace()
+                      }}
+                      className={`leave-btn flex items-center text-xs font-medium cursor-pointer rounded-md px-2 py-1 transition-colors hover:bg-red-500/10 hover:text-red-500 whitespace-nowrap ${
+                        leaveLoading
+                          ? "text-gray-500 cursor-not-allowed opacity-50"
+                          : "text-red-400"
+                      }`}
+                    >
+                      <LogOut className="mr-1 h-3 w-3 flex-shrink-0" />
+                      {leaveLoading ? "Leaving..." : "Leave"}
+                    </span>
+                  ) : (
+                    <span
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (!joinLoading) handleJoinSpace()
+                      }}
+                      className={`inline-flex items-center rounded-md border border-sidebar-accent bg-sidebar-accent/10 px-3 py-1 text-xs font-medium ring-offset-background transition-colors whitespace-nowrap ${
+                        joinLoading
+                          ? "text-gray-500 cursor-not-allowed opacity-50"
+                          : "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      }`}
+                    >
+                      <PlusCircle className="mr-1 h-3 w-3 flex-shrink-0" />
+                      {joinLoading ? "Joining..." : "Join"}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
 
           {/* space overview */}


### PR DESCRIPTION
🚀 Feature/Fix: Space Header UI Alignment

This PR resolves an overlap issue in the Space header on narrow screens, ensuring the Space name is always fully visible and correctly positioned relative to the action button.

🐛 Problem

Previously, the "Join" / "Joined" button, particularly on devices with limited screen width (e.g., mobile view or narrow browser windows), would aggressively push the Space name, causing the text to truncate or overlap the button itself. This resulted in poor readability and a misaligned UI in the header section.

Affected Component: SpaceHeader.tsx (or similar component containing the Space name and action button).

✅ Solution (The Fix)

I've updated the layout of the header container to ensure proper responsiveness and content flow.

The core of the fix involved:

    Enabling Flexbox Wrapping: The header container's display properties were adjusted to use flex-wrap (or equivalent mobile-first responsive classes) to allow the content blocks (Name/Stats and Action Button) to wrap onto separate lines when horizontal space is constrained.

    Layout Priority: This guarantees that the action button drops below the Space name and member count when necessary, preventing horizontal collision.