### PR TITLE
SPRK-386 fix/editor-word-break

### DIFF
--- a/src/components/common/RichEditorFormat.css
+++ b/src/components/common/RichEditorFormat.css
@@ -64,6 +64,8 @@
   transition:
     color 0.2s ease,
     text-decoration 0.2s ease;
+  word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 .rich-editor a:hover {

--- a/src/components/common/RichEditorFormat.css
+++ b/src/components/common/RichEditorFormat.css
@@ -19,8 +19,8 @@
 
 .rich-editor p {
   font-size: 16px;
-  word-break: break-all;
-  overflow-wrap: anywhere;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 .rich-editor ul {
@@ -53,8 +53,8 @@
 
 .rich-editor li {
   line-height: 1.6;
-  word-break: break-all;
-  overflow-wrap: anywhere;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 .rich-editor a {
@@ -86,6 +86,6 @@
 }
 
 .rich-editor {
-  word-break: break-all;
-  overflow-wrap: anywhere;
+  word-break: normal;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Fix: Prevent word breaking mid-word in Tiptap editor

### Problem
The rich text editor was breaking words in the middle (e.g., "Lorem" was being split as "Lore" and "m") due to incorrect CSS word-break settings.

### Root Cause
The CSS was using `word-break: break-all` and `overflow-wrap: anywhere`, which breaks words at any character position, even in the middle of words.

### Solution
Updated `RichEditorFormat.css` to use proper word-breaking properties:
- Changed `word-break: break-all` → `word-break: normal`
- Changed `overflow-wrap: anywhere` → `overflow-wrap: break-word`

### Changes
- Updated `.rich-editor`, `.rich-editor p`, and `.rich-editor li` CSS rules
- Words now break only at natural boundaries (spaces, hyphens)
- Long words that don't fit will still break to prevent overflow, but only as a last resort

### Testing
- ✅ Text wraps correctly at word boundaries
- ✅ No mid-word breaking for normal text

### Before/After
**Before:** "Lorem Ipsum" → "Lore|m Ipsum"  
**After:** "Lorem Ipsum" → "Lorem|Ipsum"