### PR TITLE
SPRK-393 feat: add completed sprints page with pagination

### DIFF
--- a/src/app/(dashboard)/project/[id]/(project-layout)/completed-sprints/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/completed-sprints/page.tsx
@@ -1,0 +1,8 @@
+import CompletedSprints from "@/src/components/Dashboard/ProjectManagement/SprintManagement/CompletedSprints"
+import React from "react"
+
+function page() {
+  return <CompletedSprints />
+}
+
+export default page

--- a/src/components/Dashboard/ProjectManagement/ProjectOverView/ProjectOverView.tsx
+++ b/src/components/Dashboard/ProjectManagement/ProjectOverView/ProjectOverView.tsx
@@ -22,6 +22,7 @@ import { GetSprintAction } from "@/src/server-actions/Sprint/sprint"
 import { SelectCurrentSprint } from "./SelectCurrentSprint"
 import moment from "moment"
 import { SprintBurnDownCard } from "./BurnDown/SprintBurnDownCard"
+import { SprintStatus } from "../constants/projectManagment"
 
 interface ProjectStats {
   totalTasks: number
@@ -101,11 +102,11 @@ function ProjectOverView() {
   const fetchSprints = async (projectId: string) => {
     const Sprints = await GetSprints({
       projectId: projectId,
-      status: ["active"]
+      status: [SprintStatus.ACTIVE]
     })
     if (Sprints?.success && Sprints.data) {
-      setSprintList(Sprints.data)
-      setCurrentSprint(Sprints.data[0])
+      setSprintList(Sprints.data.sprints)
+      setCurrentSprint(Sprints.data.sprints[0])
     }
   }
 

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/CompletedSprints.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/CompletedSprints.tsx
@@ -1,0 +1,118 @@
+"use client"
+import Loader from "@/src/components/common/Loader/Loader"
+import { LoaderSizes } from "@/src/components/common/types/loader-types"
+import { useServerAction } from "@/src/hooks/useServerAction"
+import { GetSprintAction } from "@/src/server-actions/Sprint/sprint"
+import React, { useEffect, useState } from "react"
+import SprintCardPage from "./SprintCard"
+import NoDataCard from "../../Channels/ChannelDetails/NoDataCard"
+import { SelectTask } from "@/src/db/schema"
+import { ChartGantt } from "lucide-react"
+import { useParams, useSearchParams } from "next/navigation"
+import { GetSprintTasksAction } from "@/src/server-actions/Tasks/Task"
+import { PaginationType } from "@/src/components/common/types/pagination.type"
+import PaginationComponent from "@/src/components/common/Pagination"
+import { useAtom } from "jotai"
+import { taskStore } from "@/src/store/tasks/taskStore"
+import { TaskModal } from "../Task/components/TaskModal"
+import { sprintStore } from "@/src/store/sprint/sprintsStore"
+
+function CompletedSprints() {
+  const [getSprintLoading, , , GetSprints] = useServerAction(GetSprintAction)
+  const [sprintList, setSprintList] = useAtom(sprintStore.sprints)
+  const [tasks, setTasks] = useState<SelectTask[]>([])
+  const [pagination, setPagination] = useState<PaginationType>()
+  const [searchParamsPage, setSearchParamsPage] = useState<string | null>(null)
+  const [selectedTask, setSelectedTask] = useAtom(taskStore.selectedTask)
+  const [isTaskModalOpen, setIsTaskModalOpen] = useAtom(
+    taskStore.isTaskModalOpen
+  )
+
+  const projectId = useParams().id as string
+
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    if (searchParams.get("page")) {
+      setSearchParamsPage(searchParams.get("page"))
+    }
+  }, [searchParams])
+
+  const fetchCompletedSprints = async () => {
+    const page = parseInt(searchParams.get("page") || "1", 10)
+    const Sprints = await GetSprints({
+      projectId: projectId,
+      status: ["closed"],
+      page: page ? page : 1,
+      limit: 4
+    })
+    if (Sprints?.success && Sprints.data) {
+      setSprintList(Sprints.data.sprints)
+      setPagination(Sprints.data.pagination)
+    }
+  }
+
+  useEffect(() => {
+    if (!projectId) return
+    fetchCompletedSprints()
+  }, [projectId, searchParamsPage])
+
+  const getSprintTasks = async () => {
+    const res = await GetSprintTasksAction({
+      project_id: projectId,
+      sprint_ids: sprintList.map((sprint) => sprint.id)
+    })
+    if (res?.success && res.data) {
+      setTasks(res.data.tasks)
+    }
+  }
+  useEffect(() => {
+    if (sprintList.length > 0) getSprintTasks()
+  }, [sprintList])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <h2 className="text-xl font-bold">Sprints History</h2>
+      </div>
+
+      <div className="space-y-4 print:space-y-3">
+        {getSprintLoading ? (
+          <div className="flex justify-center items-center my-6">
+            <Loader size={LoaderSizes.lg} />
+          </div>
+        ) : sprintList.length > 0 ? (
+          <>
+            {sprintList.map((sprint) => (
+              <SprintCardPage
+                key={sprint.id}
+                sprint={sprint}
+                tasks={tasks}
+                isSprintCompleted={true}
+                isTaskModalOpen={isTaskModalOpen}
+                setIsTaskModalOpen={setIsTaskModalOpen}
+              />
+            ))}
+
+            {pagination && <PaginationComponent pagination={pagination} />}
+          </>
+        ) : (
+          <NoDataCard
+            title="No Sprints Found"
+            description="Create a new sprint to start managing your project tasks."
+            icon={<ChartGantt className="h-10 w-10 text-muted-foreground" />}
+          />
+        )}
+      </div>
+
+      <TaskModal
+        selectedTask={selectedTask ?? undefined}
+        isTaskModelOpen={isTaskModalOpen}
+        setIsTaskModelOpen={setIsTaskModalOpen}
+        isSprintCompleted={true}
+      />
+    </div>
+  )
+}
+
+export default CompletedSprints

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/CreateSprintModal.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/CreateSprintModal.tsx
@@ -28,6 +28,7 @@ import { useParams } from "next/navigation"
 import React, { Dispatch, SetStateAction, useEffect, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 import { set, z } from "zod"
+import { SprintStatus } from "../constants/projectManagment"
 
 interface Props {
   isCreateSprintOpen: boolean
@@ -127,7 +128,7 @@ function CreateSprintModal({
       const payload = {
         ...data,
         projectId: projectId,
-        sprint_status: "upcoming"
+        sprint_status: SprintStatus.UPCOMING
       }
       const sprint = await CreateSprint(payload)
       if (sprint?.success && sprint.data) {

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
@@ -19,7 +19,7 @@ import { GetSprintTasksAction } from "@/src/server-actions/Tasks/Task"
 import pusherClient from "@/src/services/realtime/PusherClient"
 import { userStore } from "@/src/store/user/userStore"
 import { taskStore } from "@/src/store/tasks/taskStore"
-import { TaskType } from "../../constants/projectManagment"
+import { SprintStatus, TaskType } from "../../constants/projectManagment"
 
 function SprintBoard() {
   const [sprintList, setSprintList] = useAtom(sprintStore.sprints)
@@ -118,10 +118,10 @@ function SprintBoard() {
     const fetchSprints = async () => {
       const Sprints = await GetSprints({
         projectId: projectId,
-        status: ["active"]
+        status: [SprintStatus.ACTIVE]
       })
       if (Sprints?.success && Sprints.data) {
-        setSprintList(Sprints.data)
+        setSprintList(Sprints.data.sprints)
       }
     }
     fetchSprints()

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintCard.tsx
@@ -26,13 +26,14 @@ import TaskFilters from "../TaskFilter/TaskFilters"
 interface Props {
   sprint: SelectSprint
   tasks: SelectTask[]
-  setTasks: Dispatch<SetStateAction<SelectTask[]>>
-  setSelectedTask: Dispatch<SetStateAction<SelectTask | null>>
-  isTaskModalOpen: boolean
-  setIsTaskModalOpen: Dispatch<SetStateAction<boolean>>
-  setSprintId: Dispatch<SetStateAction<string>>
-  getTaskLoading: boolean
+  setTasks?: Dispatch<SetStateAction<SelectTask[]>>
+  setSelectedTask?: Dispatch<SetStateAction<SelectTask | null>>
+  isTaskModalOpen?: boolean
+  setIsTaskModalOpen?: Dispatch<SetStateAction<boolean>>
+  setSprintId?: Dispatch<SetStateAction<string>>
+  getTaskLoading?: boolean
   selectedTask?: SelectTask
+  isSprintCompleted?: boolean
 }
 
 export default function SprintCardPage({
@@ -44,7 +45,8 @@ export default function SprintCardPage({
   isTaskModalOpen,
   setIsTaskModalOpen,
   setTasks,
-  getTaskLoading
+  getTaskLoading,
+  isSprintCompleted
 }: Props) {
   const [filteredTasks, setFilteredTasks] = useState<SelectTask[]>([])
   const [isSprintContextMenuOpen, setIsSprintContextMenuOpen] = useState(false)
@@ -82,9 +84,9 @@ export default function SprintCardPage({
   ])
 
   useEffect(() => {
-    if (tasks.length > 0 && sprint.id) {
+    if (tasks?.length > 0 && sprint.id) {
       setFilteredTasks(
-        tasks.filter((t) => t?.sprint_id && t.sprint_id === sprint.id)
+        tasks?.filter((t) => t?.sprint_id && t.sprint_id === sprint.id)
       )
     }
   }, [tasks, sprint.id])
@@ -128,23 +130,25 @@ export default function SprintCardPage({
                 onApplyFilters={HandleTaskFilters}
               />
 
-              {canCreateTask && (
-                <Button
-                  variant={"outline"}
-                  onClick={() => {
-                    setIsTaskModalOpen(true)
-                    setSprintId(sprint.id ?? "")
-                  }}
-                >
-                  Add Task
-                </Button>
-              )}
+              {canCreateTask &&
+                (!isSprintCompleted ? (
+                  <Button
+                    variant={"outline"}
+                    onClick={() => {
+                      setIsTaskModalOpen?.(true)
+                      setSprintId?.(sprint.id ?? "")
+                    }}
+                  >
+                    Add Task
+                  </Button>
+                ) : null)}
 
               <SprintContextMenu
                 sprintTasks={filteredTasks}
                 sprint={sprint}
                 isSprintContextMenuOpen={isSprintContextMenuOpen}
                 setIsSprintContextMenuOpen={setIsSprintContextMenuOpen}
+                isSprintCompleted={isSprintCompleted}
               />
             </div>
           </div>
@@ -178,6 +182,7 @@ export default function SprintCardPage({
                   currSprint={sprint}
                   setIsTaskModelOpen={setIsTaskModalOpen}
                   setTasks={setTasks}
+                  isSprintCompleted={isSprintCompleted}
                 />
               ))
             ) : (

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
@@ -120,8 +120,8 @@ function SprintContextMenu({
         sprint_status: SprintStatus.ACTIVE
       })
       if (res?.success && res.data) {
-        setSprintList((prev) =>
-          prev.map((s) => (s.id === res.data.id ? res.data : s))
+        setSprintList((prevSprints) =>
+          prevSprints.filter((s) => s.id !== res.data.id)
         )
       }
     }
@@ -143,8 +143,8 @@ function SprintContextMenu({
     } else {
       const res = await UpdateSprint(sprint.id, { sprint_status: "closed" })
       if (res?.success && res.data) {
-        setSprintList((prev) =>
-          prev.map((s) => (s.id === res.data.id ? res.data : s))
+        setSprintList((prevSprints) =>
+          prevSprints.filter((s) => s.id !== res.data.id)
         )
       }
     }

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
@@ -191,11 +191,7 @@ function SprintContextMenu({
                   >
                     Reopen Sprint
                   </DropdownMenuItem>
-                ) : (
-                  <DropdownMenuItem onClick={() => HandleEndSprint(sprint)}>
-                    Close Sprint
-                  </DropdownMenuItem>
-                )}
+                ) : null}
               </>
             ) : (
               <>

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
@@ -32,19 +32,22 @@ import { usePermissionChecker } from "@/src/hooks/usePermissionChecker"
 import { useParams } from "next/navigation"
 import { projectStore } from "@/src/store/project/projectStore"
 import { taskStore } from "@/src/store/tasks/taskStore"
+import { SprintStatus } from "../constants/projectManagment"
 
 interface Props {
   isSprintContextMenuOpen: boolean
   setIsSprintContextMenuOpen: Dispatch<SetStateAction<boolean>>
   sprint: SelectSprint
   sprintTasks: SelectTask[]
+  isSprintCompleted?: boolean
 }
 
 function SprintContextMenu({
   sprint,
   sprintTasks,
   isSprintContextMenuOpen,
-  setIsSprintContextMenuOpen
+  setIsSprintContextMenuOpen,
+  isSprintCompleted
 }: Props) {
   const params = useParams()
   const projectId = params.id as string
@@ -113,7 +116,9 @@ function SprintContextMenu({
 
   async function HandleStartSprint(sprint: SelectSprint) {
     if (sprint) {
-      const res = await UpdateSprint(sprint.id, { sprint_status: "active" })
+      const res = await UpdateSprint(sprint.id, {
+        sprint_status: SprintStatus.ACTIVE
+      })
       if (res?.success && res.data) {
         setSprintList((prev) =>
           prev.map((s) => (s.id === res.data.id ? res.data : s))
@@ -173,33 +178,47 @@ function SprintContextMenu({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {canUpdate && (
-              <DropdownMenuItem onClick={() => EditSprint(sprint)}>
-                Edit Sprint
-              </DropdownMenuItem>
-            )}
-            {sprint.sprint_status !== "active" ? (
-              <DropdownMenuItem
-                onClick={() => {
-                  HandleStartSprint(sprint)
-                }}
-              >
-                Start Sprint
-              </DropdownMenuItem>
-            ) : null}
-            <DropdownMenuItem onClick={() => HandleEndSprint(sprint)}>
-              End Sprint
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            {canDelete && (
-              <DropdownMenuItem
-                className="text-red-500 "
-                onClick={() => {
-                  canDeleteSprint(sprint.id)
-                }}
-              >
-                Delete Sprint
-              </DropdownMenuItem>
+            {isSprintCompleted ? (
+              <>
+                {sprint.sprint_status === "closed" ? (
+                  <DropdownMenuItem onClick={() => HandleStartSprint(sprint)}>
+                    Reopen Sprint
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem onClick={() => HandleEndSprint(sprint)}>
+                    Close Sprint
+                  </DropdownMenuItem>
+                )}
+              </>
+            ) : (
+              <>
+                {canUpdate && (
+                  <DropdownMenuItem onClick={() => EditSprint(sprint)}>
+                    Edit Sprint
+                  </DropdownMenuItem>
+                )}
+
+                {sprint.sprint_status !== SprintStatus.ACTIVE ? (
+                  <DropdownMenuItem onClick={() => HandleStartSprint(sprint)}>
+                    Start Sprint
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem onClick={() => HandleEndSprint(sprint)}>
+                    End Sprint
+                  </DropdownMenuItem>
+                )}
+
+                <DropdownMenuSeparator />
+
+                {canDelete && (
+                  <DropdownMenuItem
+                    className="text-red-500"
+                    onClick={() => canDeleteSprint(sprint.id)}
+                  >
+                    Delete Sprint
+                  </DropdownMenuItem>
+                )}
+              </>
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintContextMenu.tsx
@@ -121,7 +121,7 @@ function SprintContextMenu({
       })
       if (res?.success && res.data) {
         setSprintList((prevSprints) =>
-          prevSprints.filter((s) => s.id !== res.data.id)
+          prevSprints.map((s) => (s.id === res.data.id ? res.data : s))
         )
       }
     }
@@ -181,7 +181,14 @@ function SprintContextMenu({
             {isSprintCompleted ? (
               <>
                 {sprint.sprint_status === "closed" ? (
-                  <DropdownMenuItem onClick={() => HandleStartSprint(sprint)}>
+                  <DropdownMenuItem
+                    onClick={async () => {
+                      await HandleStartSprint(sprint)
+                      setSprintList((prev) =>
+                        prev.filter((s) => s.id !== sprint.id)
+                      )
+                    }}
+                  >
                     Reopen Sprint
                   </DropdownMenuItem>
                 ) : (

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useParams } from "next/navigation"
+import { useParams, useRouter } from "next/navigation"
 import CreateSprintModal from "./CreateSprintModal"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useAtom, useAtomValue } from "jotai"
@@ -26,7 +26,7 @@ import { SelectSprint } from "@/src/db/schema"
 import { userStore } from "@/src/store/user/userStore"
 import TaskMoveDialog from "../Task/components/task-move-dialog"
 import ConfirmationDialog from "../Task/components/ConfirmationDialog"
-import { TaskType } from "../constants/projectManagment"
+import { SprintStatus, TaskType } from "../constants/projectManagment"
 
 export function SprintManagement() {
   const [sprintList, setSprintList] = useAtom(sprintStore.sprints)
@@ -56,20 +56,22 @@ export function SprintManagement() {
   )
   const taskMoveDialogAction = useAtomValue(taskStore.taskMoveDialogAction)
   const [isInitailDataLoad, setIsInitailDataLoad] = useState(false)
+  const [isNavigating, setIsNavigating] = useState(false)
 
   const [getSprintLoading, , , GetSprints] = useServerAction(GetSprintAction)
 
   const projectId = useParams().id as string
+  const router = useRouter()
 
   // Get Sprints
   useEffect(() => {
     const fetchSprints = async () => {
       const Sprints = await GetSprints({
         projectId: projectId,
-        status: ["active", "upcoming"]
+        status: [SprintStatus.ACTIVE, SprintStatus.UPCOMING]
       })
       if (Sprints?.success && Sprints.data) {
-        setSprintList(Sprints.data)
+        setSprintList(Sprints.data.sprints)
       }
     }
     fetchSprints()
@@ -192,16 +194,30 @@ export function SprintManagement() {
     ? permissionChecker?.canAccess("project.sprint.create")
     : false
 
+  const handleNavigateToCompleted = async () => {
+    setIsNavigating(true)
+    router.push(`/project/${projectId}/completed-sprints`)
+  }
+
   return projectStatusList.length > 0 ? (
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h2 className="text-xl font-bold">Sprint Management</h2>
-        {canCreate && (
-          <Button onClick={() => setIsCreateSprintOpen(true)}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create Sprint
+        <div className="flex flex-row items-center gap-2">
+          <Button
+            variant="outline"
+            loading={isNavigating}
+            onClick={handleNavigateToCompleted}
+          >
+            Show Completed Sprints
           </Button>
-        )}
+          {canCreate && (
+            <Button onClick={() => setIsCreateSprintOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Sprint
+            </Button>
+          )}
+        </div>
       </div>
 
       <div className="space-y-4 print:space-y-3">

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintTasks.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintTasks.tsx
@@ -48,15 +48,17 @@ import { DynamicIcon, IconName } from "lucide-react/dynamic"
 interface Props {
   task: SelectTask
   currSprint: SelectSprint
-  setIsTaskModelOpen: Dispatch<SetStateAction<boolean>>
-  setTasks: Dispatch<SetStateAction<SelectTask[]>>
+  setIsTaskModelOpen?: Dispatch<SetStateAction<boolean>>
+  setTasks?: Dispatch<SetStateAction<SelectTask[]>>
+  isSprintCompleted?: boolean
 }
 
 function SprintTasks({
   task,
   currSprint,
   setIsTaskModelOpen,
-  setTasks
+  setTasks,
+  isSprintCompleted
 }: Props) {
   const [status, setStatus] = useAtom(projectStore.projectStatusList)
   const [isAlertOpen, setIsAlertOpen] = useState(false)
@@ -76,7 +78,7 @@ function SprintTasks({
 
   function EditTask(task: SelectTask) {
     setSelectedTaskForEdit(task)
-    setIsTaskModelOpen(true)
+    setIsTaskModelOpen?.(true)
   }
 
   async function handleRemoveTask(task: SelectTask) {
@@ -87,7 +89,9 @@ function SprintTasks({
         await RemoveTask(id, { sprint_id: null })
       }
 
-      setTasks((prevTasks) => prevTasks.filter((t) => !taskIds.includes(t.id)))
+      setTasks?.((prevTasks) =>
+        prevTasks.filter((t) => !taskIds.includes(t.id))
+      )
 
       toast({
         title: "Task and its subtasks removed from sprint successfully",
@@ -253,31 +257,34 @@ function SprintTasks({
         </div>
 
         <div className="col-span-1 text-center">
-          {canUpdateTask && (
-            <DropdownMenu
-              open={isTaskDropDownOpen}
-              onOpenChange={(open) => setIsTaskDropDownOpen(open)}
-            >
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => {
-                    setIsTaskDropDownOpen(false)
-                    setIsAlertOpen(true)
-                  }}
-                >
-                  Move to Backlog
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => moveTask(task.id)}>
-                  Move to other Sprint
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+          {canUpdateTask &&
+            (isSprintCompleted ? (
+              <span>-</span>
+            ) : (
+              <DropdownMenu
+                open={isTaskDropDownOpen}
+                onOpenChange={(open) => setIsTaskDropDownOpen(open)}
+              >
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setIsTaskDropDownOpen(false)
+                      setIsAlertOpen(true)
+                    }}
+                  >
+                    Move to Backlog
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => moveTask(task.id)}>
+                    Move to other Sprint
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ))}
         </div>
       </div>
 

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -74,6 +74,7 @@ interface Props {
   loading?: boolean
   setIsChanged?: Dispatch<SetStateAction<boolean>>
   onSubTaskCreate?: (task: SelectTask) => void
+  isSprintCompleted?: boolean
 }
 
 const projectSchema = z.object({
@@ -95,7 +96,8 @@ export default function TaskForm({
   onSubmit,
   loading = false,
   setIsChanged,
-  onSubTaskCreate
+  onSubTaskCreate,
+  isSprintCompleted
 }: Props) {
   const [activeField, setActiveField] = useState<string | null>(null)
   const [usersList, setUsersList] = useState<(SelectUser | null)[]>([])
@@ -432,6 +434,8 @@ export default function TaskForm({
     }
   }
 
+  const isEditable = isAllowedAction && !isSprintCompleted
+
   return (
     <>
       <div className="grid grid-cols-12 gap-2 ">
@@ -455,7 +459,7 @@ export default function TaskForm({
                           className="col-span-3 !text-lg"
                           autoFocus
                           required
-                          disabled={!isAllowedAction}
+                          disabled={!isEditable}
                           onBlur={() => setActiveField(null)}
                         />
                       ) : (
@@ -500,7 +504,7 @@ export default function TaskForm({
                         value={field.value}
                         onChange={field.onChange}
                         image_uploading={true}
-                        editable={isAllowedAction}
+                        editable={isEditable}
                       />
                     ) : (
                       <div
@@ -539,7 +543,7 @@ export default function TaskForm({
                         <SubTask
                           key={subtask.id}
                           subtask={subtask}
-                          isAllowedAction={isAllowedAction}
+                          isAllowedAction={isEditable}
                           projectId={projectId}
                           statuses={statuses}
                           setSubTasks={setSubTasks}
@@ -557,7 +561,7 @@ export default function TaskForm({
                   selectedTask={selectedTask}
                   toDoStatusId={toDoStatus?.id}
                   setSubTasks={setSubTasks}
-                  isAllowedAction={isAllowedAction}
+                  isAllowedAction={isEditable}
                   onSubTaskCreate={onSubTaskCreate}
                 />
               </div>
@@ -586,7 +590,7 @@ export default function TaskForm({
               <Card>
                 <CardContent className="pt-6">
                   <div className="flex items-center justify-end gap-4 mb-2">
-                    {isAllowedAction && (
+                    {isEditable && (
                       <Button
                         loading={loading}
                         variant={"outline"}
@@ -615,7 +619,7 @@ export default function TaskForm({
                             <Select
                               onValueChange={field.onChange}
                               value={field.value}
-                              disabled={!isAllowedAction}
+                              disabled={!isEditable}
                             >
                               <SelectTrigger
                                 id="status_id"
@@ -672,7 +676,7 @@ export default function TaskForm({
                             <MultiSelect
                               options={assigneeOptions}
                               selected={selectedAssignee}
-                              disabled={!isAllowedAction}
+                              disabled={!isEditable}
                               onChange={(newselected) => {
                                 handleChangeInAssignTo(newselected)
                               }}
@@ -725,7 +729,7 @@ export default function TaskForm({
                             <MultiSelect
                               options={assignorOptions}
                               selected={selectedAssignor}
-                              disabled={!isAllowedAction}
+                              disabled={!isEditable}
                               onChange={(newselected) => {
                                 const latestSelected =
                                   newselected?.[newselected.length - 1]
@@ -784,7 +788,7 @@ export default function TaskForm({
                             <Select
                               value={field.value}
                               onValueChange={field.onChange}
-                              disabled={!isAllowedAction}
+                              disabled={!isEditable}
                             >
                               <SelectTrigger
                                 id="task_priority"
@@ -859,7 +863,7 @@ export default function TaskForm({
                             <Select
                               value={field.value}
                               onValueChange={field.onChange}
-                              disabled={!isAllowedAction}
+                              disabled={!isEditable}
                             >
                               <SelectTrigger
                                 id="task_type"
@@ -920,7 +924,7 @@ export default function TaskForm({
                         render={({ field }) =>
                           activeField === "points" ? (
                             <Input
-                              disabled={!isAllowedAction}
+                              disabled={!isEditable}
                               id="story_points"
                               type="number"
                               min={0}
@@ -1022,7 +1026,7 @@ export default function TaskForm({
                                   type="button"
                                   variant="outline"
                                   className="w-full justify-start"
-                                  disabled={!isAllowedAction || isTaskEpic}
+                                  disabled={!isEditable || isTaskEpic}
                                   onClick={() => {
                                     setActiveField("parent")
                                     setPopoverOpen(true)

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -988,6 +988,7 @@ export default function TaskForm({
                                   <div
                                     className="flex items-center gap-2 rounded-md border p-2 cursor-pointer"
                                     onClick={() => {
+                                      if (!isEditable || isTaskEpic) return
                                       setActiveField("parent")
                                       setPopoverOpen(true)
                                     }}

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -570,7 +570,10 @@ export default function TaskForm({
               {selectedTask && (
                 <div className="space-y-4 pl-2">
                   <h2 className="text-lg  font-semibold">Comments</h2>
-                  <TaskComment taskId={selectedTask.id} />
+                  <TaskComment
+                    taskId={selectedTask.id}
+                    isSprintCompleted={isSprintCompleted}
+                  />
                 </div>
               )}
             </div>

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
@@ -167,18 +167,8 @@ export const TaskModal = ({
             isTaskModelOpen={isTaskModelOpen}
             setIsChanged={setIsChanged}
             onSubTaskCreate={onSubTaskCreate}
+            isSprintCompleted={isSprintCompleted}
           />
-          <ScrollArea className="max-h-[80vh]">
-            <TaskForm
-              statuses={statuses}
-              onSubmit={handleSubmit}
-              selectedTask={internalTask}
-              loading={isLoading}
-              isTaskModelOpen={isTaskModelOpen}
-              setIsChanged={setIsChanged}
-              isSprintCompleted={isSprintCompleted}
-            />
-          </ScrollArea>
         </DialogContent>
       </Dialog>
 

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
@@ -35,6 +35,7 @@ interface TaskModalProps {
   onUpdateComplete?: (task: SelectTask) => void
   isReady?: boolean
   onSubTaskCreate?: (task: SelectTask) => void
+  isSprintCompleted?: boolean
 }
 
 export const TaskModal = ({
@@ -45,7 +46,8 @@ export const TaskModal = ({
   onUpdateComplete,
   sprintId,
   isReady,
-  onSubTaskCreate
+  onSubTaskCreate,
+  isSprintCompleted = false
 }: TaskModalProps) => {
   const setSelectedTask = useSetAtom(taskStore.selectedTask)
   const [taskIdFromUrl, setTaskIdFromUrl] = useState<string | null>(null)
@@ -166,6 +168,17 @@ export const TaskModal = ({
             setIsChanged={setIsChanged}
             onSubTaskCreate={onSubTaskCreate}
           />
+          <ScrollArea className="max-h-[80vh]">
+            <TaskForm
+              statuses={statuses}
+              onSubmit={handleSubmit}
+              selectedTask={internalTask}
+              loading={isLoading}
+              isTaskModelOpen={isTaskModelOpen}
+              setIsChanged={setIsChanged}
+              isSprintCompleted={isSprintCompleted}
+            />
+          </ScrollArea>
         </DialogContent>
       </Dialog>
 

--- a/src/components/Dashboard/ProjectManagement/Task/components/task-comment.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/task-comment.tsx
@@ -17,10 +17,14 @@ import { formatRelativeTime } from "@/src/utils/helpers"
 
 interface TaskCommentFormProps {
   taskId: string
+  isSprintCompleted?: boolean
 }
 const COMMENTS_PER_LOAD = 4
 
-export function TaskComment({ taskId }: TaskCommentFormProps) {
+export function TaskComment({
+  taskId,
+  isSprintCompleted
+}: TaskCommentFormProps) {
   const authUser = useAtomValue(userStore.AuthUser)
   const userId = authUser?.unique_id
   const { toast } = useToast()
@@ -100,7 +104,11 @@ export function TaskComment({ taskId }: TaskCommentFormProps) {
         <div className="grid gap-2">
           {isEditing ? (
             <div className="space-y-3">
-              <Tiptap value={commentContent} onChange={setCommentContent} />
+              <Tiptap
+                value={commentContent}
+                onChange={setCommentContent}
+                editable={!isSprintCompleted}
+              />
               <div className="flex gap-2 justify-end">
                 <Button
                   type="button"
@@ -113,7 +121,11 @@ export function TaskComment({ taskId }: TaskCommentFormProps) {
                 <Button
                   type="button"
                   onClick={handleAddComment}
-                  disabled={!commentContent.trim() || creatingComment}
+                  disabled={
+                    !commentContent.trim() ||
+                    creatingComment ||
+                    isSprintCompleted
+                  }
                   loading={creatingComment}
                 >
                   {creatingComment ? "Adding..." : "Comment"}

--- a/src/components/Dashboard/ProjectManagement/Task/components/task-move-dialog.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/task-move-dialog.tsx
@@ -31,6 +31,7 @@ import { useAtom, useSetAtom } from "jotai"
 import { taskStore } from "@/src/store/tasks/taskStore"
 import { toast } from "@/src/hooks/use-toast"
 import { sprintStore } from "@/src/store/sprint/sprintsStore"
+import { SprintStatus } from "../../constants/projectManagment"
 
 interface Props {
   isTaskMoveDialogOpen: boolean
@@ -70,10 +71,10 @@ export default function TaskMoveDialog({
     const fetchSprints = async () => {
       const Sprints = await GetSprints({
         projectId: projectId,
-        status: ["active", "upcoming"]
+        status: [SprintStatus.ACTIVE, SprintStatus.UPCOMING]
       })
       if (Sprints?.success && Sprints.data) {
-        setSprintList(Sprints.data)
+        setSprintList(Sprints.data.sprints)
       }
     }
     fetchSprints()

--- a/src/components/Dashboard/ProjectManagement/Task/components/task-move-dialog.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/task-move-dialog.tsx
@@ -141,9 +141,7 @@ export default function TaskMoveDialog({
 
     const res = await UpdateSprint(currSprintId, { sprint_status: "closed" })
     if (res?.success && res.data) {
-      setSprintList((prev) =>
-        prev.map((s) => (s.id === res.data.id ? res.data : s))
-      )
+      setSprintList((prev) => prev.filter((s) => s.id !== res.data.id))
       setIsTaskMoveDialogOpen(false)
     }
   }

--- a/src/components/Dashboard/ProjectManagement/constants/projectManagment.ts
+++ b/src/components/Dashboard/ProjectManagement/constants/projectManagment.ts
@@ -18,6 +18,12 @@ export enum TaskPriority {
   HIGHEST = "highest"
 }
 
+export enum SprintStatus {
+  UPCOMING = "upcomming",
+  ACTIVE = "active",
+  ENDED = "ended"
+}
+
 export const projectTaskTypes = [
   {
     key: TaskType.STORY,
@@ -191,19 +197,19 @@ export const ProjectManagementPages = [
   }
 ]
 
-export const SprintStatus = [
+export const sprintStatuses = [
   {
-    key: "upcomming",
+    key: SprintStatus.UPCOMING,
     title: "Upcoming",
     badgeVariants: "outline"
   },
   {
-    key: "active",
+    key: SprintStatus.ACTIVE,
     title: "Active",
     badgeVariants: "default"
   },
   {
-    key: "ended",
+    key: SprintStatus.ENDED,
     title: "Ended",
     badgeVariants: "secondary"
   }

--- a/src/db/data-access/sprints/query.ts
+++ b/src/db/data-access/sprints/query.ts
@@ -2,8 +2,11 @@ import { and, desc, eq, gte, inArray, SQLWrapper } from "drizzle-orm"
 import { db } from "../.."
 import { SelectSprint, sprintBurnDownTable, SprintTable } from "../../schema"
 import moment from "moment"
+import { SprintStatus } from "@/src/components/Dashboard/ProjectManagement/constants/projectManagment"
 
 export type sprintQueryFilters = {
+  page?: number
+  limit?: number
   projectId?: string
   status?: string[]
 }
@@ -20,6 +23,10 @@ export async function CreateSprint(sprintData: SelectSprint) {
 
 export async function getSprints(filters?: sprintQueryFilters) {
   try {
+    const page = filters?.page
+    const limit = filters?.limit
+    const offset = page && limit ? (page - 1) * limit : 0
+
     const whereClauses: (SQLWrapper | undefined)[] = []
 
     if (filters) {
@@ -33,10 +40,26 @@ export async function getSprints(filters?: sprintQueryFilters) {
     }
 
     const sprints = await db.query.SprintTable.findMany({
+      limit: limit,
+      offset: offset,
       where: whereClauses.length ? and(...whereClauses) : undefined
     })
 
-    return sprints
+    const totalCount = await db.$count(
+      SprintTable,
+      whereClauses.length ? and(...whereClauses) : undefined
+    )
+
+    return {
+      sprints,
+      pagination: {
+        total: Number(totalCount),
+        page: page || 1,
+        limit: limit || 0,
+        totalPages:
+          limit && limit !== 0 ? Math.ceil(Number(totalCount) / limit) : 1
+      }
+    }
   } catch (e: any) {
     throw new Error(e.message)
   }
@@ -148,7 +171,7 @@ export const getRecentlyUpdatedSprints = async () => {
       .where(
         and(
           gte(SprintTable.updated_at, fifteenMinutesAgo),
-          eq(SprintTable.sprint_status, "active")
+          eq(SprintTable.sprint_status, SprintStatus.ACTIVE)
         )
       )
 


### PR DESCRIPTION
This PR introduces a new page displaying all completed or closed sprints.
The page is designed to be read-only, showing sprint and task details without allowing modifications.
A “Reopen Sprint” action has been added to enable users to reactivate a completed sprint when necessary.
Pagination has also been implemented to improve performance and user experience, displaying 4 sprints per page.

**Changes:**
- Added `CompletedSprints` component.
- Integrated sprint data filtering by status.
- Implemented pagination with a limit of 4 sprints per page.
- Disabled sprint/task action buttons on this page.
- Added logic for reopening a sprint.
- UI updates for a clean read-only layout.

**Testing:**
- Verified that only completed/closed sprints are displayed.
- Checked that pagination works correctly (4 sprints per page).
- Confirmed that no actions are available except “Reopen Sprint.”
- Tested reopening to ensure the sprint’s status changes accordingly.