### PR TITLE
Fix: Task limit filter not working in backlog

### DIFF
--- a/src/components/Dashboard/ProjectManagement/BacklogManagement/BacklogItemsCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/BacklogManagement/BacklogItemsCard.tsx
@@ -65,7 +65,7 @@ function BacklogItemsCard({ searchedItem, orderList, limit, filters }: Props) {
 
   useEffect(() => {
     if (searchedItem || orderList) fatchTasks()
-  }, [searchedItem, orderList, searchParamsPage])
+  }, [searchedItem, orderList, searchParamsPage, limit])
 
   useEffect(() => {
     if (filters) fatchTasks()


### PR DESCRIPTION
### Summary
Fixed an issue where the task limit filter in the backlog page was not functioning properly. 

### Changes
- Corrected the logic handling the limit filter (10, 20, 30 tasks per page).
- Verified pagination and limit-based data fetching now work as expected.

### Testing
- Selected different limit options (10, 20, 30) in backlog.
- Confirmed that tasks display according to the selected limit.

### Result
Task limit filter now works correctly in the backlog page.
