### PR TITLE
SW-17-truncate and fixed folder name

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirNav.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirNav.tsx
@@ -3,6 +3,12 @@ import { ChevronLeft } from "lucide-react"
 import { useAtom } from "jotai"
 import { spaceStore } from "@/src/store/space/spaceStore"
 import React from "react"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider
+} from "@/src/components/ui/tooltip"
 
 type DirNavProps = {
   navigateToFolder: (path: string) => Promise<void>
@@ -21,14 +27,21 @@ const DirNav: React.FC<DirNavProps> = ({ navigateToFolder }) => {
         return (
           <div key={segmentPath} className="flex items-center">
             <span className="mx-1 text-muted-foreground">/</span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="px-1 h-7"
-              onClick={() => navigateToFolder(segmentPath)}
-            >
-              {segment}
-            </Button>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  // limit width and apply ellipsis
+                  className="px-1 h-7 max-w-[200px] truncate text-left"
+                  onClick={() => navigateToFolder(segmentPath)}
+                >
+                  <span className="truncate block">{segment}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{segment}</TooltipContent>
+            </Tooltip>
           </div>
         )
       })
@@ -56,7 +69,7 @@ const DirNav: React.FC<DirNavProps> = ({ navigateToFolder }) => {
             <ChevronLeft className="h-4 w-4" />
           </Button>
         )}
-        <div className="flex items-center text-sm">
+        <div className="flex items-center text-sm overflow-hidden whitespace-nowrap">
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
@@ -170,7 +170,7 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder }) => {
                 )}
               </div>
               <div
-                className={`font-medium ${
+                className={`font-medium truncate ${
                   item.type === "folder"
                     ? "cursor-pointer hover:text-primary"
                     : ""

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -399,9 +399,18 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
               <div className="grid gap-4">
                 <Input
                   placeholder="Folder name"
+                  maxLength={100}
                   onChange={(e) => {
-                    setNewFolderError("")
-                    newFolderName.current = e.target.value
+                    const value = e.target.value
+                    newFolderName.current = value
+
+                    if (value.length === 100) {
+                      setNewFolderError(
+                        "Folder name reached 100 characters limit"
+                      )
+                    } else {
+                      setNewFolderError("")
+                    }
                   }}
                 />
               </div>

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -335,6 +335,16 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
       })
     }
   }
+  const handleFolderNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    newFolderName.current = value
+
+    if (value.length === 100) {
+      setNewFolderError("Folder name reached 100 characters limit")
+    } else {
+      setNewFolderError("")
+    }
+  }
 
   return (
     <section className="directory">
@@ -400,18 +410,7 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
                 <Input
                   placeholder="Folder name"
                   maxLength={100}
-                  onChange={(e) => {
-                    const value = e.target.value
-                    newFolderName.current = value
-
-                    if (value.length === 100) {
-                      setNewFolderError(
-                        "Folder name reached 100 characters limit"
-                      )
-                    } else {
-                      setNewFolderError("")
-                    }
-                  }}
+                  onChange={handleFolderNameChange}
                 />
               </div>
               {newFolderError && (


### PR DESCRIPTION
[SW-17](https://spark.etlonline.org/project/08ce22b9-6738-47dd-9acf-b544d832e04d/board?task_id=a78bee01-58f9-4e6d-954e-b2e6709b87e6)

**Description**

1. Open Spark → Communities → Channels → Spaces → File Sharing.
2. Create a new folder with an extremely long name.
3. Observe the folder navigation bar and page layout.

**Actual Result:**
The long folder name causes the UI to shift left, leaving part of the interface (including action buttons) hidden or inaccessible.

**Expected Result:**
The system should automatically truncate long folder names with ellipsis (e.g., TestingTestingTesting…) or wrap text within limits, or a limit on folder name length keeping the UI properly aligned and fully visible.

**Fix Implemented**
- Maximum folder name length set to 100 characters.
- Implemented truncation with ellipsis for overly long names.
- Ensured the UI remains fully visible and properly aligned.
- Displayed a warning message when the character limit is reached.

