### PR TITLE
SW-9 Prevent duplicate file names in the same folder

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -37,6 +37,7 @@ import DirNav from "./DirNav"
 import { FileUpload } from "@/src/components/ui/file-upload"
 import { useSearchParams } from "next/navigation"
 import { CreateNewFileAction } from "@/src/server-actions/FileSharing/FileSharing"
+import { getUniqueFileName } from "./utils/helper"
 
 type FileData = {
   fileName: string
@@ -282,18 +283,33 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
   }
   const handleFileUpload = async () => {
     try {
+      if (!fileData) return
+
+      const currentFolder =
+        currentPath === "/"
+          ? dir
+          : findItemByPath(dir, currentPath)?.children || []
+
+      const existingNames = currentFolder
+        .filter((item) => item.type === "file")
+        .map((item) => item.name.toLowerCase())
+
+      const originalName = fileData.fileName
+
+      const uniqueFileName = getUniqueFileName(originalName, existingNames)
       const createdFile = (
         await createNewFile(
           currentPath === "/"
             ? (currSpace?.id as string)
             : (findItemByPath(dir, currentPath)?.id as number),
-          fileData?.fileName as string,
-          fileData?.fileSize as number,
-          fileData?.fileB64string as string,
-          fileData?.fileType as string,
+          uniqueFileName,
+          fileData.fileSize,
+          fileData.fileB64string,
+          fileData.fileType,
           "spaces"
         )
       )?.data
+
       const newFile: DirItem = {
         id: createdFile?.id as number,
         name: createdFile?.entity_name as string,
@@ -320,17 +336,16 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
       }
 
       setFileData(null)
-
       setIsNewFileDrawerOpen(false)
 
       toast({
-        description: "File created!",
+        description: `File uploaded as "${uniqueFileName}"`,
         duration: 3000
       })
     } catch (error) {
       toast({
         variant: "destructive",
-        description: "Failed to create file",
+        description: "Failed to upload file",
         duration: 3000
       })
     }

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/utils/helper.ts
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/utils/helper.ts
@@ -1,0 +1,19 @@
+export function getUniqueFileName(
+  originalName: string,
+  existingNames: string[]
+) {
+  const dotIndex = originalName.lastIndexOf(".")
+  const baseName =
+    dotIndex !== -1 ? originalName.slice(0, dotIndex) : originalName
+  const extension = dotIndex !== -1 ? originalName.slice(dotIndex) : ""
+
+  let counter = 1
+  let newName = originalName.toLowerCase()
+
+  while (existingNames.includes(newName)) {
+    newName = `${baseName}(${counter})${extension}`.toLowerCase()
+    counter++
+  }
+
+  return newName
+}


### PR DESCRIPTION
### Issue
Currently, the system allows users to upload files with identical names in the same folder. This can cause confusion, accidental overwriting, and download issues.

### Steps to Reproduce
1. Open Spark → Community → Channels → Spaces → File Sharing.
2. Upload the same file multiple times in the same folder.
3. Observe that files appear with identical names.

### Expected Behavior
The system should automatically rename duplicate files by appending a counter in brackets:
- Lecture 3.pptx
- Lecture 3 (2).pptx
- Lecture 3 (3).pptx
…and so on.

### Actual Behavior
Identical file names are allowed in the same folder.

### Solution
Implemented logic to check existing file names in a folder and append a counter for duplicates, ensuring unique file names while maintaining the original base name.
