### PR TITLE
SW-33 Fix: Prevent submission of empty  comments

### DIFF
--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -181,8 +181,6 @@ export default function RichTextEditor({
     onUpdate({ editor }) {
       const html = editor.getHTML()
       if (onChange) {
-        console.log("Editor HTML:", html)
-        console.log("Editor isContentEmpty:", isContentEmpty(html))
         onChange(isContentEmpty(html) ? "" : html)
       }
     }

--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -97,6 +97,15 @@ export default function RichTextEditor({
     }
   })
 
+  const isContentEmpty = (html: string) => {
+    if (!html) return true
+    const text = html
+      .replace(/<[^>]*>/g, "")
+      .replace(/&nbsp;/g, "")
+      .trim()
+    return text === ""
+  }
+
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -172,7 +181,9 @@ export default function RichTextEditor({
     onUpdate({ editor }) {
       const html = editor.getHTML()
       if (onChange) {
-        onChange(html)
+        console.log("Editor HTML:", html)
+        console.log("Editor isContentEmpty:", isContentEmpty(html))
+        onChange(isContentEmpty(html) ? "" : html)
       }
     }
   })


### PR DESCRIPTION
This update fixes an issue where users could submit empty comments under tasks.
Previously, the comment button became active even if the input contained only spaces or was cleared after typing.

**Changes made:**
- Added validation to check for empty or whitespace-only comments.
- Comment button now stays disabled until valid content is entered.

**Result:**
Users can no longer submit blank comments, ensuring cleaner and more meaningful discussions under tasks.