### PR TITLE
SW-18 prevent scroll animation on first load

### DIFF
--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -148,6 +148,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
     chatStore.isMobileMenuOpen
   )
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const initialChatLoadRef = useRef<boolean>(true)
   const [currentChat, setCurrentChat] = useAtom(chatStore.currentChat)
   const [switchedChat, setSwitchedChat] = useAtom(chatStore.switchedChat)
   const [myChats, setMyChats] = useAtom(chatStore.myChats)
@@ -172,7 +173,10 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     setCurrentChat(currentChatSSR || null)
     setMyChats(allChatsSSR || [])
-    setMessages(currentChatSSR?.messages || [])
+    initialChatLoadRef.current = true
+    const initialMessages = currentChatSSR?.messages || []
+
+    setMessages(initialMessages)
     scrollToBottom()
     return () => {
       setCurrentChat(null)
@@ -180,10 +184,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       setMessages([])
     }
   }, [])
-
   const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  }, [messages])
+    const behavior: ScrollBehavior = initialChatLoadRef.current
+      ? "auto"
+      : "smooth"
+    messagesEndRef.current?.scrollIntoView({ behavior })
+    initialChatLoadRef.current = false
+  }, [])
 
   useEffect(() => {
     if (!currentChat || !authUser) return
@@ -243,6 +250,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
    * @returns {Promise<void>} A promise that resolves when the chat has been switched.
    */
   const handleChatSwitch = async (chatId: number) => {
+    initialChatLoadRef.current = true
     const newSwitchedChat = await fetchChatWithMessages(chatId)
     if (newSwitchedChat && newSwitchedChat.data) {
       setCurrentChat(newSwitchedChat.data)


### PR DESCRIPTION
[SW-18](https://spark.etlonline.org/project/08ce22b9-6738-47dd-9acf-b544d832e04d/board?task_id=4660a5de-1bf0-4839-bd51-15e6a9e96fa1)

**Description**

1. Navigate to the Chat section in Space.
2. Open any chat or group conversation.
3. Observe the message area as the chat loads.

Note: When the user opens any chat, all messages slide down automatically from top to bottom instead of appearing in a stable, static view.

**Actual Result:**
- 1. Messages scroll automatically from top to bottom when the chat opens.
- 2. This causes unnecessary animation and distraction for users.

**Expected Result:**
- The chat should open smoothly without any scrolling or movement.
