### PR TITLE
SW-154 Fix: Filters reset after creating or updating a task in Board and Sprint views

### DIFF
--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
@@ -61,10 +61,27 @@ function SprintBoardCard({
     useServerAction(GetSprintTasksAction)
 
   useEffect(() => {
-    if (tasks.length > 0) {
-      setFilteredTasks(tasks.filter((task) => task.sprint_id === sprint.id))
+    if (!sprint.id) return
+
+    if (filters && tasks?.length > 0) {
+      const filtered = tasks.filter((t) => {
+        return (
+          t?.sprint_id === sprint.id &&
+          (!filters.priority?.length ||
+            filters.priority.includes(t.task_priority)) &&
+          (!filters.type?.length || filters.type.includes(t.task_type)) &&
+          (!filters.status?.length ||
+            filters.status.includes(t.status_id || "")) &&
+          (!filters.assignee?.length ||
+            filters.assignee.includes(t.assign_to || ""))
+        )
+      })
+
+      setFilteredTasks(filtered)
+    } else if (tasks?.length > 0) {
+      setFilteredTasks(tasks.filter((t) => t?.sprint_id === sprint.id))
     }
-  }, [tasks])
+  }, [tasks, sprint.id, filters])
 
   useEffect(() => {
     const getTask = async () => {

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintCard.tsx
@@ -84,12 +84,27 @@ export default function SprintCardPage({
   ])
 
   useEffect(() => {
-    if (tasks?.length > 0 && sprint.id) {
-      setFilteredTasks(
-        tasks?.filter((t) => t?.sprint_id && t.sprint_id === sprint.id)
-      )
+    if (!sprint.id) return
+
+    if (filters && tasks?.length > 0) {
+      const filtered = tasks.filter((t) => {
+        return (
+          t?.sprint_id === sprint.id &&
+          (!filters.priority?.length ||
+            filters.priority.includes(t.task_priority)) &&
+          (!filters.type?.length || filters.type.includes(t.task_type)) &&
+          (!filters.status?.length ||
+            filters.status.includes(t.status_id || "")) &&
+          (!filters.assignee?.length ||
+            filters.assignee.includes(t.assign_to || ""))
+        )
+      })
+
+      setFilteredTasks(filtered)
+    } else if (tasks?.length > 0) {
+      setFilteredTasks(tasks.filter((t) => t?.sprint_id === sprint.id))
     }
-  }, [tasks, sprint.id])
+  }, [tasks, sprint.id, filters])
 
   // PERMISSIONS INITATE
   const { permissionChecker } = usePermissionChecker(

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
@@ -92,15 +92,8 @@ export function SprintManagement() {
   useEffect(() => {
     if (projectId && sprintList.length > 0 && tasks.length === 0) {
       fetchTasks()
-      console.log("Fetching tasks after update...")
     }
   }, [projectId, sprintList])
-
-  useEffect(() => {
-    if (tasks.length > 0) {
-      console.log("Tasks updated:", tasks)
-    }
-  }, [tasks])
 
   useEffect(() => {
     if (tasks.length > 0) {

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
@@ -92,8 +92,15 @@ export function SprintManagement() {
   useEffect(() => {
     if (projectId && sprintList.length > 0 && tasks.length === 0) {
       fetchTasks()
+      console.log("Fetching tasks after update...")
     }
   }, [projectId, sprintList])
+
+  useEffect(() => {
+    if (tasks.length > 0) {
+      console.log("Tasks updated:", tasks)
+    }
+  }, [tasks])
 
   useEffect(() => {
     if (tasks.length > 0) {


### PR DESCRIPTION
Issue:
In the Board and Sprint views, applied filters (such as status, assignee, or priority) are automatically cleared when a user creates or updates a task. This forces users to manually reapply filters, disrupting their workflow.

Expected Behavior:
Filters should persist after creating or updating tasks — similar to how they currently behave in the Backlog view.

**Fix Implemented:**
- Ensured filter states are preserved in the Board and Sprint views after task creation or updates.
- Adjusted state management logic to prevent unnecessary resets.

**Testing Steps:**

- Go to the Board or Sprint view.
- Apply filters (e.g., Status = “In Progress”, Assignee = “Hamza”).
- Create or update a task.
- Confirm that filters remain applied and the view is still filtered correctly.