### PR TITLE
Feature/sw-2 restrict duplicate group names

### DIFF
--- a/src/components/Dashboard/Chat/components/CreateNewChat.tsx
+++ b/src/components/Dashboard/Chat/components/CreateNewChat.tsx
@@ -135,9 +135,8 @@ const CreateNewChat = () => {
         )
 
         if (response.success === false && response.error) {
-          // Check for the specific error returned by the server action
           setGroupNameError(response.error)
-          setIsCreatingChat(false) // Stop loading
+          setIsCreatingChat(false)
           return
         }
         if (response.success && response.data) {
@@ -175,18 +174,14 @@ const CreateNewChat = () => {
         }
       }
 
-      // --- FINAL SUCCESS CLEANUP ---
       setSelectedContacts([])
       setGroupName("")
       setIsGroupChat(false)
       setDialogOpen(false)
     } catch (e) {
-      // Catch any uncaught errors during execution
       console.error("Uncaught error during chat creation:", e)
       setGroupNameError("An unexpected error occurred.")
     } finally {
-      // Ensure loading state is off unless a return happened previously
-      // and it was handled (like in the duplicate check or validation).
       setIsCreatingChat(false)
     }
   }

--- a/src/components/Dashboard/Chat/components/CreateNewChat.tsx
+++ b/src/components/Dashboard/Chat/components/CreateNewChat.tsx
@@ -112,6 +112,8 @@ const CreateNewChat = () => {
   const handleCreateNewChat = async () => {
     if (!authUser) return
     setIsCreatingChat(true)
+    setGroupNameError("")
+
     const spaceId = currentSpace && isSpacePage ? currentSpace.id : undefined
     const userIds = selectedContacts.map((contact) => contact.value)
     try {
@@ -119,18 +121,25 @@ const CreateNewChat = () => {
         // Create Group Chat
         if (groupName.trim() === "") {
           setGroupNameError("Group name is required.")
+          setIsCreatingChat(false) 
           return
         } else if (groupName.trim().length > 50) {
           setGroupNameError("Group name must be 50 characters or less.")
+          setIsCreatingChat(false) 
           return
-        } else {
-          setGroupNameError("")
         }
         const response = await CreateGroupChatAction(
           [...userIds, authUser?.unique_id],
           groupName,
           spaceId
         )
+
+        if (response.success === false && response.error) {
+          // Check for the specific error returned by the server action
+          setGroupNameError(response.error)
+          setIsCreatingChat(false) // Stop loading
+          return
+        }
         if (response.success && response.data) {
           const newChat = response.data
           setMyChats((pre) => [...pre, newChat])
@@ -165,11 +174,19 @@ const CreateNewChat = () => {
           })
         }
       }
+
+      // --- FINAL SUCCESS CLEANUP ---
       setSelectedContacts([])
       setGroupName("")
       setIsGroupChat(false)
       setDialogOpen(false)
+    } catch (e) {
+      // Catch any uncaught errors during execution
+      console.error("Uncaught error during chat creation:", e)
+      setGroupNameError("An unexpected error occurred.")
     } finally {
+      // Ensure loading state is off unless a return happened previously
+      // and it was handled (like in the duplicate check or validation).
       setIsCreatingChat(false)
     }
   }

--- a/src/db/data-access/chat/query.ts
+++ b/src/db/data-access/chat/query.ts
@@ -7,6 +7,7 @@ import {
   inArray,
   like,
   or,
+  sql,
   SQLWrapper
 } from "drizzle-orm"
 import { db } from "../.."
@@ -502,6 +503,44 @@ export const getExistingSingleChat = async (
     })
   } catch (error: any) {
     console.log(error.message, "error")
+    throw new Error(error.message)
+  }
+}
+
+export const getExistingGroupName = async (
+  chatName: string,
+  space_id?: string
+) => {
+  try {
+    if (!space_id) {
+      return undefined
+    }
+
+    const existingChat = await db.query.chatsTable.findFirst({
+      where: and(
+        eq(chatsTable.is_group, 1),
+        eq(chatsTable.name, chatName),
+
+        inArray(
+          chatsTable.id,
+          sql`${db
+            .select({ chat_id: SpaceChatsTable.chat_id })
+            .from(SpaceChatsTable)
+            .where(eq(SpaceChatsTable.space_id, space_id))}`
+        )
+      ),
+      with: {
+        users: {
+          with: {
+            user: true
+          }
+        }
+      }
+    })
+
+    return existingChat
+  } catch (error: any) {
+    console.error("Error during group name check:", error.message)
     throw new Error(error.message)
   }
 }

--- a/src/db/data-access/chat/query.ts
+++ b/src/db/data-access/chat/query.ts
@@ -20,6 +20,7 @@ import {
   usersTable
 } from "../../schema"
 import { randomUUID } from "crypto"
+import { slugify } from "@/src/utils/helpers"
 
 export const CreatePrivateChat = async (
   user_id: string,
@@ -83,6 +84,7 @@ export const CreateGroupChat = async (
         type: space_id ? "space" : "open",
         name: chatName,
         channel_id: realtimeChannelId,
+        chat_slug: slugify(chatName),
         is_group: 1
       })
       .returning()
@@ -515,11 +517,11 @@ export const getExistingGroupName = async (
     if (!space_id) {
       return undefined
     }
-
+    const chatNamePattern = slugify(chatName);
     const existingChat = await db.query.chatsTable.findFirst({
       where: and(
         eq(chatsTable.is_group, 1),
-        eq(chatsTable.name, chatName),
+        eq(chatsTable.chat_slug, chatNamePattern),
 
         inArray(
           chatsTable.id,

--- a/src/db/seeds/ChatSlugCorrectionSyncSeed.ts
+++ b/src/db/seeds/ChatSlugCorrectionSyncSeed.ts
@@ -1,0 +1,35 @@
+import { sql } from "drizzle-orm"
+import { db } from ".."
+import { chatsTable } from "../schema"
+import { slugify } from "@/src/utils/helpers"
+
+export const ChatSlugCorrectionSyncSeed = async () => {
+  return await db.transaction(async (tx) => {
+    try {
+      // Fetch all chat records
+      const chats = await tx.select().from(chatsTable)
+      
+      console.log(`📊 Found ${chats.length} chats to process`)
+      
+      // Update each chat with slugified name
+      for (const chat of chats) {
+        if (chat.name) {
+          const slug = slugify(chat.name)
+          
+          await tx
+            .update(chatsTable)
+            .set({ chat_slug: slug })
+            .where(sql`${chatsTable.id} = ${chat.id}`)
+        }
+      }
+      
+      console.log("✅ Chat slugs updated successfully")
+      
+    } catch (e) {
+      console.error(e)
+      tx.rollback()
+      console.log("❌ Error updating chat slugs")
+      process.exit(1)
+    }
+  })
+}

--- a/src/db/seeds/EmailTemplatesSeed.ts
+++ b/src/db/seeds/EmailTemplatesSeed.ts
@@ -58,6 +58,3 @@ export const EmailTemplatesSeed = async () => {
     }
   })
 }
-
-// You can call the function directly if you want this file to be executable
-EmailTemplatesSeed()

--- a/src/db/seeds/index.ts
+++ b/src/db/seeds/index.ts
@@ -12,6 +12,7 @@ import { SyncRolePermissionsSeeder } from "./SyncScopedPermissions"
 import { siteSettingsSeed } from "./SiteSettingsSeed"
 import { UpdateRoleTable } from "./UpdateRolesTable"
 import { EmailTemplatesSeed } from "./EmailTemplatesSeed"
+import { ChatSlugCorrectionSyncSeed } from "./ChatSlugCorrectionSyncSeed"
 
 const SEEDERS: Record<string, () => Promise<void>> = {
   FeatureSeed,
@@ -27,7 +28,8 @@ const SEEDERS: Record<string, () => Promise<void>> = {
   CheckRolePermissionMismatch,
   SyncRolePermissionsSeeder,
   siteSettingsSeed,
-  EmailTemplatesSeed
+  EmailTemplatesSeed,
+  ChatSlugCorrectionSyncSeed
 }
 
 async function runSeeders() {
@@ -40,7 +42,8 @@ async function runSeeders() {
       "NewTagsSeed",
       "CheckRolePermissionMismatch",
       "SyncRolePermissionsSeeder",
-      "EmailTemplatesSeed"
+      "EmailTemplatesSeed",
+      "ChatSlugCorrectionSyncSeed"
     ]
 
     const seederNames =

--- a/src/server-actions/Chat/Chat.ts
+++ b/src/server-actions/Chat/Chat.ts
@@ -9,7 +9,8 @@ import {
   GetMutualChat,
   GetChats,
   updateLastChatMessage,
-  getExistingSingleChat
+  getExistingSingleChat,
+  getExistingGroupName
 } from "@/src/db/data-access/chat/query"
 import { CreateServerAction } from ".."
 import { InsertMessage } from "@/src/db/schema"
@@ -83,6 +84,17 @@ export const CreateGroupChatAction = CreateServerAction(
   true,
   async (userIds: string[], chatName: string, space_id?: string) => {
     try {
+      if (space_id) {
+        const existingChat = await getExistingGroupName(chatName, space_id)
+
+        if (existingChat) {
+          return {
+            success: false,
+            error:
+              "A group with this name already exists in this space. Please choose a different name."
+          }
+        }
+      }
       const authUser = await AuthUserAction()
       const space = await GetSpaceById(space_id || "")
 

--- a/src/server-actions/Chat/Chat.ts
+++ b/src/server-actions/Chat/Chat.ts
@@ -87,7 +87,7 @@ export const CreateGroupChatAction = CreateServerAction(
       if (space_id) {
         const existingChat = await getExistingGroupName(chatName, space_id)
 
-        if (existingChat) {
+        if (existingChat?.name?.toLowerCase() ==chatName.toLocaleLowerCase()) {
           return {
             success: false,
             error:


### PR DESCRIPTION
Fix: Prevent Duplicate Group Names
Problem
Users could create multiple groups with identical names, causing confusion when identifying chats (e.g., multiple "Testing" groups).
Solution

Added validation to check for existing group names before creation
Implemented unique constraint on group names
Display error message when duplicate name is detected: "A group with this name already exists. Please choose a different name."

Changes

✅ Only unique group names are now allowed
✅ System validates name availability before creating new groups
✅ Clear validation feedback for users