### PR TITLE
Dev release 1.1.11

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirNav.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirNav.tsx
@@ -3,6 +3,12 @@ import { ChevronLeft } from "lucide-react"
 import { useAtom } from "jotai"
 import { spaceStore } from "@/src/store/space/spaceStore"
 import React from "react"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider
+} from "@/src/components/ui/tooltip"
 
 type DirNavProps = {
   navigateToFolder: (path: string) => Promise<void>
@@ -21,14 +27,21 @@ const DirNav: React.FC<DirNavProps> = ({ navigateToFolder }) => {
         return (
           <div key={segmentPath} className="flex items-center">
             <span className="mx-1 text-muted-foreground">/</span>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="px-1 h-7"
-              onClick={() => navigateToFolder(segmentPath)}
-            >
-              {segment}
-            </Button>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  // limit width and apply ellipsis
+                  className="px-1 h-7 max-w-[200px] truncate text-left"
+                  onClick={() => navigateToFolder(segmentPath)}
+                >
+                  <span className="truncate block">{segment}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top">{segment}</TooltipContent>
+            </Tooltip>
           </div>
         )
       })
@@ -56,7 +69,7 @@ const DirNav: React.FC<DirNavProps> = ({ navigateToFolder }) => {
             <ChevronLeft className="h-4 w-4" />
           </Button>
         )}
-        <div className="flex items-center text-sm">
+        <div className="flex items-center text-sm overflow-hidden whitespace-nowrap">
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
@@ -170,7 +170,7 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder }) => {
                 )}
               </div>
               <div
-                className={`font-medium ${
+                className={`font-medium truncate ${
                   item.type === "folder"
                     ? "cursor-pointer hover:text-primary"
                     : ""

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -399,9 +399,18 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
               <div className="grid gap-4">
                 <Input
                   placeholder="Folder name"
+                  maxLength={100}
                   onChange={(e) => {
-                    setNewFolderError("")
-                    newFolderName.current = e.target.value
+                    const value = e.target.value
+                    newFolderName.current = value
+
+                    if (value.length === 100) {
+                      setNewFolderError(
+                        "Folder name reached 100 characters limit"
+                      )
+                    } else {
+                      setNewFolderError("")
+                    }
                   }}
                 />
               </div>

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -335,6 +335,16 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
       })
     }
   }
+  const handleFolderNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    newFolderName.current = value
+
+    if (value.length === 100) {
+      setNewFolderError("Folder name reached 100 characters limit")
+    } else {
+      setNewFolderError("")
+    }
+  }
 
   return (
     <section className="directory">
@@ -400,18 +410,7 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
                 <Input
                   placeholder="Folder name"
                   maxLength={100}
-                  onChange={(e) => {
-                    const value = e.target.value
-                    newFolderName.current = value
-
-                    if (value.length === 100) {
-                      setNewFolderError(
-                        "Folder name reached 100 characters limit"
-                      )
-                    } else {
-                      setNewFolderError("")
-                    }
-                  }}
+                  onChange={handleFolderNameChange}
                 />
               </div>
               {newFolderError && (

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -37,6 +37,7 @@ import DirNav from "./DirNav"
 import { FileUpload } from "@/src/components/ui/file-upload"
 import { useSearchParams } from "next/navigation"
 import { CreateNewFileAction } from "@/src/server-actions/FileSharing/FileSharing"
+import { getUniqueFileName } from "./utils/helper"
 
 type FileData = {
   fileName: string
@@ -282,18 +283,33 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
   }
   const handleFileUpload = async () => {
     try {
+      if (!fileData) return
+
+      const currentFolder =
+        currentPath === "/"
+          ? dir
+          : findItemByPath(dir, currentPath)?.children || []
+
+      const existingNames = currentFolder
+        .filter((item) => item.type === "file")
+        .map((item) => item.name.toLowerCase())
+
+      const originalName = fileData.fileName
+
+      const uniqueFileName = getUniqueFileName(originalName, existingNames)
       const createdFile = (
         await createNewFile(
           currentPath === "/"
             ? (currSpace?.id as string)
             : (findItemByPath(dir, currentPath)?.id as number),
-          fileData?.fileName as string,
-          fileData?.fileSize as number,
-          fileData?.fileB64string as string,
-          fileData?.fileType as string,
+          uniqueFileName,
+          fileData.fileSize,
+          fileData.fileB64string,
+          fileData.fileType,
           "spaces"
         )
       )?.data
+
       const newFile: DirItem = {
         id: createdFile?.id as number,
         name: createdFile?.entity_name as string,
@@ -320,17 +336,16 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
       }
 
       setFileData(null)
-
       setIsNewFileDrawerOpen(false)
 
       toast({
-        description: "File created!",
+        description: `File uploaded as "${uniqueFileName}"`,
         duration: 3000
       })
     } catch (error) {
       toast({
         variant: "destructive",
-        description: "Failed to create file",
+        description: "Failed to upload file",
         duration: 3000
       })
     }

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/utils/helper.ts
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/utils/helper.ts
@@ -1,0 +1,19 @@
+export function getUniqueFileName(
+  originalName: string,
+  existingNames: string[]
+) {
+  const dotIndex = originalName.lastIndexOf(".")
+  const baseName =
+    dotIndex !== -1 ? originalName.slice(0, dotIndex) : originalName
+  const extension = dotIndex !== -1 ? originalName.slice(dotIndex) : ""
+
+  let counter = 1
+  let newName = originalName.toLowerCase()
+
+  while (existingNames.includes(newName)) {
+    newName = `${baseName}(${counter})${extension}`.toLowerCase()
+    counter++
+  }
+
+  return newName
+}

--- a/src/components/Dashboard/Chat/components/ChatsList.tsx
+++ b/src/components/Dashboard/Chat/components/ChatsList.tsx
@@ -2,19 +2,19 @@ import { ScrollArea } from "@radix-ui/react-scroll-area"
 import React, { useMemo } from "react"
 import { Avatar, AvatarFallback, AvatarImage } from "../../../ui/avatar"
 import { Badge } from "../../../ui/badge"
-import { useAtom, useAtomValue, useSetAtom } from "jotai"
+import { useAtom, useAtomValue } from "jotai"
 import { chatStore } from "@/src/store/chat/chatStore"
 import { userStore } from "@/src/store/user/userStore"
-import { SelectChat, SelectUser } from "@/src/db/schema"
 import Loader from "../../../common/Loader/Loader"
 import ChatContactItem from "./ChatContactItem"
+import moment from "moment"
 
 const ChatsList = ({ searchQuery = "" }) => {
   const [myChats, setMyChats] = useAtom(chatStore.myChats)
   const authUser = useAtomValue(userStore.AuthUser)
 
   const filteredChats = useMemo(() => {
-    return myChats.filter((chat) => {
+    const chats = myChats.filter((chat) => {
       if (!searchQuery.trim()) return true
       const query = searchQuery.toLowerCase().replace(/\s+/g, "")
       if (
@@ -42,6 +42,10 @@ const ChatsList = ({ searchQuery = "" }) => {
       }
       return false
     })
+
+    return chats.sort(
+      (a, b) => moment(b.updated_at).valueOf() - moment(a.updated_at).valueOf()
+    )
   }, [myChats, searchQuery])
 
   return (

--- a/src/components/Dashboard/Chat/components/CreateNewChat.tsx
+++ b/src/components/Dashboard/Chat/components/CreateNewChat.tsx
@@ -135,9 +135,8 @@ const CreateNewChat = () => {
         )
 
         if (response.success === false && response.error) {
-          // Check for the specific error returned by the server action
           setGroupNameError(response.error)
-          setIsCreatingChat(false) // Stop loading
+          setIsCreatingChat(false)
           return
         }
         if (response.success && response.data) {
@@ -175,18 +174,14 @@ const CreateNewChat = () => {
         }
       }
 
-      // --- FINAL SUCCESS CLEANUP ---
       setSelectedContacts([])
       setGroupName("")
       setIsGroupChat(false)
       setDialogOpen(false)
     } catch (e) {
-      // Catch any uncaught errors during execution
       console.error("Uncaught error during chat creation:", e)
       setGroupNameError("An unexpected error occurred.")
     } finally {
-      // Ensure loading state is off unless a return happened previously
-      // and it was handled (like in the duplicate check or validation).
       setIsCreatingChat(false)
     }
   }

--- a/src/components/Dashboard/Chat/components/CreateNewChat.tsx
+++ b/src/components/Dashboard/Chat/components/CreateNewChat.tsx
@@ -112,6 +112,8 @@ const CreateNewChat = () => {
   const handleCreateNewChat = async () => {
     if (!authUser) return
     setIsCreatingChat(true)
+    setGroupNameError("")
+
     const spaceId = currentSpace && isSpacePage ? currentSpace.id : undefined
     const userIds = selectedContacts.map((contact) => contact.value)
     try {
@@ -119,18 +121,25 @@ const CreateNewChat = () => {
         // Create Group Chat
         if (groupName.trim() === "") {
           setGroupNameError("Group name is required.")
+          setIsCreatingChat(false) 
           return
         } else if (groupName.trim().length > 50) {
           setGroupNameError("Group name must be 50 characters or less.")
+          setIsCreatingChat(false) 
           return
-        } else {
-          setGroupNameError("")
         }
         const response = await CreateGroupChatAction(
           [...userIds, authUser?.unique_id],
           groupName,
           spaceId
         )
+
+        if (response.success === false && response.error) {
+          // Check for the specific error returned by the server action
+          setGroupNameError(response.error)
+          setIsCreatingChat(false) // Stop loading
+          return
+        }
         if (response.success && response.data) {
           const newChat = response.data
           setMyChats((pre) => [...pre, newChat])
@@ -165,11 +174,19 @@ const CreateNewChat = () => {
           })
         }
       }
+
+      // --- FINAL SUCCESS CLEANUP ---
       setSelectedContacts([])
       setGroupName("")
       setIsGroupChat(false)
       setDialogOpen(false)
+    } catch (e) {
+      // Catch any uncaught errors during execution
+      console.error("Uncaught error during chat creation:", e)
+      setGroupNameError("An unexpected error occurred.")
     } finally {
+      // Ensure loading state is off unless a return happened previously
+      // and it was handled (like in the duplicate check or validation).
       setIsCreatingChat(false)
     }
   }

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -24,7 +24,6 @@ import {
   SelectUserChat
 } from "@/src/db/schema"
 import { userStore } from "@/src/store/user/userStore"
-// REMOVED: import { AblyClient } from "@/src/services/realtime/AblyClient" // Removed AblyClient
 import ChatsList from "./components/ChatsList"
 import {
   AddMessageToChatAction,
@@ -46,7 +45,7 @@ import {
 } from "../../ui/emoji-picker"
 import { spaceStore } from "@/src/store/space/spaceStore"
 import { usePermissionChecker } from "@/src/hooks/usePermissionChecker"
-import pusherClient from "@/src/services/realtime/PusherClient" // Keep PusherClient
+import pusherClient from "@/src/services/realtime/PusherClient"
 
 interface ChatScreenProps {
   currentChatSSR: SelectChat | undefined
@@ -58,11 +57,38 @@ type ChatUpdatePayload = {
   lastMessage: string
 }
 
-// Function to join a channel (for group or one-to-one chat)
+const sortChats = (chats: SelectChat[]): SelectChat[] => {
+  return [...chats].sort((a, b) => {
+    const dateAString = a.updated_at
+    const dateBString = b.updated_at
+
+    const dateA = dateAString ? new Date(dateAString).getTime() : 0
+    const dateB = dateBString ? new Date(dateBString).getTime() : 0
+
+    return dateB - dateA
+  })
+}
+
+const updateAndSortChats = (
+  prevChats: SelectChat[],
+  updatedChatData: SelectChat
+) => {
+  const otherChats = prevChats.filter((chat) => chat.id !== updatedChatData.id)
+
+  const existingChat = prevChats.find((chat) => chat.id === updatedChatData.id)
+  const newChat = existingChat
+    ? { ...existingChat, ...updatedChatData }
+    : updatedChatData
+
+  const newChatsList = [newChat, ...otherChats]
+
+  return sortChats(newChatsList)
+}
+
 /**
- * Joins a specified channel and sets up message subscription.
+ * Joins a specified channel for a chat.
  *
- * @param {string} channelName - The name of the channel to join (e.g., 'private-chat-123').
+ * @param {number} chatId - The ID of the chat to join.
  * @param {(message: SelectMessage) => void} onMessageReceived - Callback function to handle received messages.
  * @returns {{ unsubscribe: () => void }} An object containing a function to unsubscribe.
  */
@@ -70,11 +96,9 @@ function joinChannel(
   chatId: number,
   onMessageReceived: (message: SelectMessage) => void
 ) {
-  // Use a Pusher private channel name convention
   const channelName = `private-chat-${chatId}`
   const channel = pusherClient.subscribe(channelName)
 
-  // Subscribe to the specific event triggered by the server action
   channel.bind("new-message", (data: { message: SelectMessage }) => {
     onMessageReceived(data.message)
   })
@@ -84,8 +108,6 @@ function joinChannel(
     pusherClient.unsubscribe(channelName)
   }
 
-  // sendMessage is removed as client-side publishing is generally insecure 
-  // and message sending now relies on the server action.
   return { unsubscribe }
 }
 
@@ -122,8 +144,9 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   const [switchedChat, setSwitchedChat] = useAtom(chatStore.switchedChat)
   const [myChats, setMyChats] = useAtom(chatStore.myChats)
   const authUser = useAtomValue(userStore.AuthUser)
-  // Updated state to only hold the unsubscribe function
-  const [chatRealTime, setChatRealtime] = useState<{ unsubscribe: () => void } | null>(null)
+  const [chatRealTime, setChatRealtime] = useState<{
+    unsubscribe: () => void
+  } | null>(null)
   const [searchQuery, setSearchQuery] = useState<string>("")
 
   const [chatContact, setChatContact] = useState<SelectUser | null>(null)
@@ -142,7 +165,8 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
 
   useEffect(() => {
     setCurrentChat(currentChatSSR || null)
-    setMyChats(allChatsSSR || [])
+
+    setMyChats(sortChats(allChatsSSR || []))
     setMessages(currentChatSSR?.messages || [])
     scrollToBottom()
     return () => {
@@ -159,32 +183,26 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     if (!currentChat || !authUser) return
 
-    // UPDATED: joinChannel now takes chat ID and returns only unsubscribe
-    const { unsubscribe } = joinChannel(
-      currentChat.id, // Use chat ID for Pusher channel naming
-      (message) => {
-        setMessages((prev) => [...prev, message])
+    const { unsubscribe } = joinChannel(currentChat.id, (message) => {
+      setMessages((prev) => [...prev, message])
 
-        // Update the last message and unread count in the chat list
-        setMyChats((prevChats) => {
-          const updatedChats = prevChats.map((chat) => {
-            if (chat.id === message.chat_id) {
-              return {
-                ...chat,
-                last_message: message.message,
-                last_message_at: message.created_at,
-                // Only reset unread count if we are currently viewing the chat
-                unread_count: 0 
-              }
-            }
-            return chat
-          })
-          return updatedChats
-        })
-      }
-    )
+      setMyChats((prevChats) => {
+        const updatedChat = prevChats.find(
+          (chat) => chat.id === message.chat_id
+        )
+        if (!updatedChat) return prevChats
 
-    // UPDATED: Set chatRealtime with only unsubscribe
+        const updatedChatData = {
+          ...updatedChat,
+          last_message: message.message,
+          last_message_at: message.created_at,
+          unread_count: 0
+        }
+
+        return updateAndSortChats(prevChats, updatedChatData)
+      })
+    })
+
     setChatRealtime({ unsubscribe })
 
     if (!currentChat.is_group) {
@@ -194,16 +212,14 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       setChatContact(chatContact || null)
     }
 
-    // This already uses pusher, so it remains the same
     const channelName = `presence-chat-${currentChat.id}`
     const presenceChannel = pusherClient.subscribe(channelName)
 
     return () => {
       unsubscribe()
-      // Pusher presence channel unsubscribe
       presenceChannel.unsubscribe()
     }
-  }, [currentChat?.id, authUser]) // Changed dependency from channel_id to id
+  }, [currentChat?.id, authUser])
 
   useEffect(() => {
     if (!switchedChat) return
@@ -215,9 +231,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
 
   /**
    * Handles switching to a different chat by fetching the chat data and its messages.
-   *
-   * @param {number} chatId - The ID of the chat to switch to.
-   * @returns {Promise<void>} A promise that resolves when the chat has been switched.
+   * ...
    */
   const handleChatSwitch = async (chatId: number) => {
     const newSwitchedChat = await fetchChatWithMessages(chatId)
@@ -239,11 +253,9 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     if (!authUser) return
 
-    // UPDATED: Use Pusher private-user channel convention
     const userChannelName = `private-user-${authUser.unique_id}`
     const userChannel = pusherClient.subscribe(userChannelName)
 
-    // UPDATED: Bind to the "chat-update" event
     userChannel.bind("chat-update", (data: { update: ChatUpdatePayload }) => {
       const update = data.update as ChatUpdatePayload
 
@@ -251,26 +263,19 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
         const updatedChat = prevChats.find((chat) => chat.id === update.chatId)
 
         if (updatedChat && update.lastMessage) {
-          const newChats = prevChats.map((chat) => {
-            if (chat.id === update.chatId) {
-              const isActiveChat = currentChat?.id === update.chatId
-              return {
-                ...chat,
-                last_message: update.lastMessage,
-                updated_at: new Date().toISOString(),
-                // Increment unread count only if not active chat
-                unread_count: isActiveChat ? 0 : (chat.unread_count || 0) + 1
-              }
-            }
-            return chat
-          })
-          return newChats
+          const isActiveChat = currentChat?.id === update.chatId
+          const updatedChatData = {
+            ...updatedChat,
+            last_message: update.lastMessage,
+            updated_at: new Date().toISOString(),
+            unread_count: isActiveChat ? 0 : (updatedChat.unread_count || 0) + 1
+          }
+          return updateAndSortChats(prevChats, updatedChatData)
         }
         return prevChats
       })
     })
 
-    // UPDATED: Bind to the "chat-created" event
     userChannel.bind(
       "chat-created",
       (data: { newChat: SelectChat; initiatorId: string; spaceId: string }) => {
@@ -281,14 +286,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
         const currentSpaceId = currentSpace?.id
 
         if (currentSpaceId === spaceId) {
-          setMyChats((prevChats) => [newChat, ...prevChats])
+          setMyChats((prevChats) => sortChats([newChat, ...prevChats]))
           setSwitchedChat(newChat)
         }
       }
     )
 
     return () => {
-      // Clean up Pusher subscriptions
       userChannel.unbind_all()
       pusherClient.unsubscribe(userChannelName)
     }
@@ -296,48 +300,36 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
 
   /**
    * Handles the sending of a new message in the chat.
-   *
-   * This function checks if the new message is not empty, creates a new message object,
-   * clears the input field, and then calls the action to add the message to the chat.
-   *
-   * @async
-   * @function handleSendMessage
-   * @returns {Promise<void>} A promise that resolves when the message has been added to the chat.
+   * ...
    */
   const handleSendMessage = async () => {
     if (newMessage.trim() === "" || !currentChat || !authUser) return
+    const messageContent = newMessage
+
     const newMsg: InsertMessage = {
       sender_id: authUser?.unique_id || "",
       chat_id: currentChat?.id || 0,
-      message: newMessage,
+      message: messageContent,
       type: "text"
     }
 
-    // The temporary message logic is now REMOVED as the message will come 
-    // back via the Pusher subscription after the server action successfully 
-    // creates and broadcasts it. This ensures the message only appears if 
-    // the server action succeeds, preventing desync.
+    setMyChats((prevChats) => {
+      const updatedChat = prevChats.find((chat) => chat.id === currentChat.id)
+      if (!updatedChat) return prevChats
 
-    // Update chat list optimistically before calling the server action
-    setMyChats((prevChats) =>
-      prevChats.map((chat) =>
-        chat.id === currentChat.id
-          ? {
-              ...chat,
-              last_message: newMsg.message,
-              last_message_at: new Date().toISOString()
-            }
-          : chat
-      )
-    )
+      const updatedChatData = {
+        ...updatedChat,
+        last_message: messageContent,
+        updated_at: new Date().toISOString()
+      }
+      return updateAndSortChats(prevChats, updatedChatData)
+    })
+
     setNewMessage("")
-    // This server action will now handle Pusher trigger for both 
-    // "new-message" on the chat channel and "chat-update" on user channels.
     await addMessageToChat(newMsg, currentSpace?.id)
   }
 
   return (
-    // ... (The rest of the component JSX remains the same)
     <div className="flex h-[calc(100vh-7rem)] gap-4">
       {/* Contacts list - visible on desktop, hidden on mobile */}
       <Card className="w-80 flex-shrink-0 border-r hidden md:flex md:flex-col h-full">
@@ -357,11 +349,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
           </div>
         </CardHeader>
         <CardContent className="flex-1 overflow-hidden p-0">
+          {/* ChatsList component will now display the properly sorted myChats */}
           {canView && <ChatsList searchQuery={searchQuery} />}
         </CardContent>
       </Card>
 
       {/* Main chat area */}
+      {/* ... (rest of the component JSX remains the same) ... */}
       {canView && (
         <Card className="flex-1 flex flex-col h-full">
           <CardHeader className="flex flex-row items-center justify-between py-4">
@@ -541,7 +535,6 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
                     value={newMessage}
                     onChange={(e) => setNewMessage(e.target.value)}
                     className="flex-1"
-                    // type="text"
                   />
                   <Popover>
                     <PopoverTrigger>

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -341,14 +341,16 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       sender_id: newMsg.sender_id,
       message: newMsg.message
     }
-
+    setMessages((prevMessages) => [...prevMessages, tempMessage])
     setMyChats((prevChats) =>
       prevChats.map((chat) =>
         chat.id === currentChat.id
           ? {
               ...chat,
               last_message: newMsg.message,
-              last_message_at: new Date().toISOString()
+              last_message_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              unread_count: 0
             }
           : chat
       )

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -57,34 +57,6 @@ type ChatUpdatePayload = {
   lastMessage: string
 }
 
-const sortChats = (chats: SelectChat[]): SelectChat[] => {
-  return [...chats].sort((a, b) => {
-    const dateAString = a.updated_at
-    const dateBString = b.updated_at
-
-    const dateA = dateAString ? new Date(dateAString).getTime() : 0
-    const dateB = dateBString ? new Date(dateBString).getTime() : 0
-
-    return dateB - dateA
-  })
-}
-
-const updateAndSortChats = (
-  prevChats: SelectChat[],
-  updatedChatData: SelectChat
-) => {
-  const otherChats = prevChats.filter((chat) => chat.id !== updatedChatData.id)
-
-  const existingChat = prevChats.find((chat) => chat.id === updatedChatData.id)
-  const newChat = existingChat
-    ? { ...existingChat, ...updatedChatData }
-    : updatedChatData
-
-  const newChatsList = [newChat, ...otherChats]
-
-  return sortChats(newChatsList)
-}
-
 /**
  * Joins a specified channel for a chat.
  *
@@ -166,7 +138,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     setCurrentChat(currentChatSSR || null)
 
-    setMyChats(sortChats(allChatsSSR || []))
+    setMyChats(allChatsSSR || [])
     setMessages(currentChatSSR?.messages || [])
     scrollToBottom()
     return () => {
@@ -183,25 +155,29 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     if (!currentChat || !authUser) return
 
-    const { unsubscribe } = joinChannel(currentChat.id, (message) => {
-      setMessages((prev) => [...prev, message])
+    const { unsubscribe } = joinChannel(
+      currentChat.id, // Use chat ID for Pusher channel naming
+      (message) => {
+        setMessages((prev) => [...prev, message])
 
-      setMyChats((prevChats) => {
-        const updatedChat = prevChats.find(
-          (chat) => chat.id === message.chat_id
-        )
-        if (!updatedChat) return prevChats
-
-        const updatedChatData = {
-          ...updatedChat,
-          last_message: message.message,
-          last_message_at: message.created_at,
-          unread_count: 0
-        }
-
-        return updateAndSortChats(prevChats, updatedChatData)
-      })
-    })
+        // Update the last message and unread count in the chat list
+        setMyChats((prevChats) => {
+          const updatedChats = prevChats.map((chat) => {
+            if (chat.id === message.chat_id) {
+              return {
+                ...chat,
+                last_message: message.message,
+                last_message_at: message.created_at,
+                // Only reset unread count if we are currently viewing the chat
+                unread_count: 0
+              }
+            }
+            return chat
+          })
+          return updatedChats
+        })
+      }
+    )
 
     setChatRealtime({ unsubscribe })
 
@@ -263,14 +239,20 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
         const updatedChat = prevChats.find((chat) => chat.id === update.chatId)
 
         if (updatedChat && update.lastMessage) {
-          const isActiveChat = currentChat?.id === update.chatId
-          const updatedChatData = {
-            ...updatedChat,
-            last_message: update.lastMessage,
-            updated_at: new Date().toISOString(),
-            unread_count: isActiveChat ? 0 : (updatedChat.unread_count || 0) + 1
-          }
-          return updateAndSortChats(prevChats, updatedChatData)
+          const newChats = prevChats.map((chat) => {
+            if (chat.id === update.chatId) {
+              const isActiveChat = currentChat?.id === update.chatId
+              return {
+                ...chat,
+                last_message: update.lastMessage,
+                updated_at: new Date().toISOString(),
+                // Increment unread count only if not active chat
+                unread_count: isActiveChat ? 0 : (chat.unread_count || 0) + 1
+              }
+            }
+            return chat
+          })
+          return newChats
         }
         return prevChats
       })
@@ -286,7 +268,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
         const currentSpaceId = currentSpace?.id
 
         if (currentSpaceId === spaceId) {
-          setMyChats((prevChats) => sortChats([newChat, ...prevChats]))
+          setMyChats((prevChats) => [newChat, ...prevChats])
           setSwitchedChat(newChat)
         }
       }
@@ -313,17 +295,17 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       type: "text"
     }
 
-    setMyChats((prevChats) => {
-      const updatedChat = prevChats.find((chat) => chat.id === currentChat.id)
-      if (!updatedChat) return prevChats
-
-      const updatedChatData = {
-        ...updatedChat,
-        last_message: messageContent,
-        updated_at: new Date().toISOString()
-      }
-      return updateAndSortChats(prevChats, updatedChatData)
-    })
+    setMyChats((prevChats) =>
+      prevChats.map((chat) =>
+        chat.id === currentChat.id
+          ? {
+              ...chat,
+              last_message: newMsg.message,
+              last_message_at: new Date().toISOString()
+            }
+          : chat
+      )
+    )
 
     setNewMessage("")
     await addMessageToChat(newMsg, currentSpace?.id)

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -24,7 +24,7 @@ import {
   SelectUserChat
 } from "@/src/db/schema"
 import { userStore } from "@/src/store/user/userStore"
-import { AblyClient } from "@/src/services/realtime/AblyClient"
+// REMOVED: import { AblyClient } from "@/src/services/realtime/AblyClient" // Removed AblyClient
 import ChatsList from "./components/ChatsList"
 import {
   AddMessageToChatAction,
@@ -46,7 +46,7 @@ import {
 } from "../../ui/emoji-picker"
 import { spaceStore } from "@/src/store/space/spaceStore"
 import { usePermissionChecker } from "@/src/hooks/usePermissionChecker"
-import pusherClient from "@/src/services/realtime/PusherClient"
+import pusherClient from "@/src/services/realtime/PusherClient" // Keep PusherClient
 
 interface ChatScreenProps {
   currentChatSSR: SelectChat | undefined
@@ -60,68 +60,38 @@ type ChatUpdatePayload = {
 
 // Function to join a channel (for group or one-to-one chat)
 /**
- * Joins a specified channel and sets up message subscription and sending functionality.
+ * Joins a specified channel and sets up message subscription.
  *
- * @param {string} channelName - The name of the channel to join.
+ * @param {string} channelName - The name of the channel to join (e.g., 'private-chat-123').
  * @param {(message: SelectMessage) => void} onMessageReceived - Callback function to handle received messages.
- * @returns {{ sendMessage: (content: any) => void }} An object containing a function to send messages to the channel.
+ * @returns {{ unsubscribe: () => void }} An object containing a function to unsubscribe.
  */
 function joinChannel(
-  channelName: string,
+  chatId: number,
   onMessageReceived: (message: SelectMessage) => void
 ) {
-  const channel = AblyClient.channels.get(channelName)
+  // Use a Pusher private channel name convention
+  const channelName = `private-chat-${chatId}`
+  const channel = pusherClient.subscribe(channelName)
 
-  // Subscribe to messages
-  channel.subscribe((message) => {
-    onMessageReceived(message.data)
+  // Subscribe to the specific event triggered by the server action
+  channel.bind("new-message", (data: { message: SelectMessage }) => {
+    onMessageReceived(data.message)
   })
 
-  // Send a message
-  function sendMessage(content: any) {
-    channel.publish("message", content)
-  }
-
   function unsubscribe() {
-    channel.unsubscribe()
-    channel.detach()
+    channel.unbind_all()
+    pusherClient.unsubscribe(channelName)
   }
 
-  return { sendMessage, unsubscribe }
+  // sendMessage is removed as client-side publishing is generally insecure 
+  // and message sending now relies on the server action.
+  return { unsubscribe }
 }
 
 /**
  * ChatScreen component renders the chat interface including the list of chats and the main chat area.
- * It handles the display of messages, sending new messages, and switching between different chats.
- *
- * @param {ChatScreenProps} props - The properties for the ChatScreen component.
- * @param {Chat} props.currentChatSSR - The current chat data fetched from the server-side rendering.
- * @param {Chat[]} props.allChatsSSR - The list of all chats fetched from the server-side rendering.
- *
- * @returns {JSX.Element} The rendered ChatScreen component.
- *
- * @component
- *
- * @example
- * // Example usage of ChatScreen component
- * <ChatScreen currentChatSSR={currentChatData} allChatsSSR={allChatsData} />
- *
- * @remarks
- * This component uses several hooks and atoms for state management and side effects:
- * - `useState` for managing local state such as messages, newMessage, isMobileMenuOpen, chat, and chatContact.
- * - `useRef` for referencing the end of the messages list to scroll into view.
- * - `useAtom` and `useAtomValue` from Jotai for managing global state related to the current chat, switched chat, and authenticated user.
- * - `useEffect` for handling side effects such as setting initial state, joining chat channels, and handling chat switches.
- * - `useCallback` for memoizing the scrollToBottom function.
- *
- * The component also includes several nested components and elements for rendering the chat interface:
- * - `Card`, `CardHeader`, `CardContent`, `CardFooter` for structuring the chat interface.
- * - `Sheet`, `SheetTrigger`, `SheetContent` for handling the mobile menu.
- * - `Link` for navigating to the chat contact's profile.
- * - `Avatar`, `AvatarImage`, `AvatarFallback` for displaying the chat contact's avatar.
- * - `ScrollArea` for displaying the list of messages with a scrollable area.
- * - `Loader` for displaying a loading indicator while fetching chat messages.
- * - `Input` and `Button` for handling the input and sending of new messages.
+ * ... (Rest of JSDoc remains the same)
  */
 export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   const currentSpace = useAtomValue(spaceStore.currentSpace)
@@ -152,7 +122,8 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   const [switchedChat, setSwitchedChat] = useAtom(chatStore.switchedChat)
   const [myChats, setMyChats] = useAtom(chatStore.myChats)
   const authUser = useAtomValue(userStore.AuthUser)
-  const [chatRealTime, setChatRealtime] = useState<any>(null)
+  // Updated state to only hold the unsubscribe function
+  const [chatRealTime, setChatRealtime] = useState<{ unsubscribe: () => void } | null>(null)
   const [searchQuery, setSearchQuery] = useState<string>("")
 
   const [chatContact, setChatContact] = useState<SelectUser | null>(null)
@@ -188,11 +159,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     if (!currentChat || !authUser) return
 
-    const { sendMessage, unsubscribe } = joinChannel(
-      currentChat.channel_id,
+    // UPDATED: joinChannel now takes chat ID and returns only unsubscribe
+    const { unsubscribe } = joinChannel(
+      currentChat.id, // Use chat ID for Pusher channel naming
       (message) => {
         setMessages((prev) => [...prev, message])
 
+        // Update the last message and unread count in the chat list
         setMyChats((prevChats) => {
           const updatedChats = prevChats.map((chat) => {
             if (chat.id === message.chat_id) {
@@ -200,7 +173,8 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
                 ...chat,
                 last_message: message.message,
                 last_message_at: message.created_at,
-                unread_count: 0
+                // Only reset unread count if we are currently viewing the chat
+                unread_count: 0 
               }
             }
             return chat
@@ -210,7 +184,8 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       }
     )
 
-    setChatRealtime({ sendMessage, unsubscribe })
+    // UPDATED: Set chatRealtime with only unsubscribe
+    setChatRealtime({ unsubscribe })
 
     if (!currentChat.is_group) {
       const chatContact = currentChat.users?.find(
@@ -219,14 +194,16 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       setChatContact(chatContact || null)
     }
 
+    // This already uses pusher, so it remains the same
     const channelName = `presence-chat-${currentChat.id}`
     const presenceChannel = pusherClient.subscribe(channelName)
 
     return () => {
       unsubscribe()
+      // Pusher presence channel unsubscribe
       presenceChannel.unsubscribe()
     }
-  }, [currentChat?.channel_id, authUser])
+  }, [currentChat?.id, authUser]) // Changed dependency from channel_id to id
 
   useEffect(() => {
     if (!switchedChat) return
@@ -262,10 +239,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     if (!authUser) return
 
-    const userChannel = AblyClient.channels.get(`user:${authUser.unique_id}`)
+    // UPDATED: Use Pusher private-user channel convention
+    const userChannelName = `private-user-${authUser.unique_id}`
+    const userChannel = pusherClient.subscribe(userChannelName)
 
-    userChannel.subscribe("chat-update", (message) => {
-      const update = message.data as ChatUpdatePayload
+    // UPDATED: Bind to the "chat-update" event
+    userChannel.bind("chat-update", (data: { update: ChatUpdatePayload }) => {
+      const update = data.update as ChatUpdatePayload
 
       setMyChats((prevChats) => {
         const updatedChat = prevChats.find((chat) => chat.id === update.chatId)
@@ -278,6 +258,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
                 ...chat,
                 last_message: update.lastMessage,
                 updated_at: new Date().toISOString(),
+                // Increment unread count only if not active chat
                 unread_count: isActiveChat ? 0 : (chat.unread_count || 0) + 1
               }
             }
@@ -289,25 +270,27 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       })
     })
 
-    userChannel.subscribe("chat-created", (message) => {
-      const { newChat, initiatorId, spaceId } = message.data as {
-        newChat: SelectChat
-        initiatorId: string
-        spaceId: string
-      }
-      if (initiatorId === authUser?.unique_id) {
-        return
-      }
-      const currentSpaceId = currentSpace?.id
+    // UPDATED: Bind to the "chat-created" event
+    userChannel.bind(
+      "chat-created",
+      (data: { newChat: SelectChat; initiatorId: string; spaceId: string }) => {
+        const { newChat, initiatorId, spaceId } = data
+        if (initiatorId === authUser?.unique_id) {
+          return
+        }
+        const currentSpaceId = currentSpace?.id
 
-      if (currentSpaceId === spaceId) {
-        setMyChats((prevChats) => [newChat, ...prevChats])
-        setSwitchedChat(newChat)
+        if (currentSpaceId === spaceId) {
+          setMyChats((prevChats) => [newChat, ...prevChats])
+          setSwitchedChat(newChat)
+        }
       }
-    })
+    )
 
     return () => {
-      userChannel.unsubscribe()
+      // Clean up Pusher subscriptions
+      userChannel.unbind_all()
+      pusherClient.unsubscribe(userChannelName)
     }
   }, [authUser, setMyChats, currentChat])
 
@@ -330,18 +313,12 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       type: "text"
     }
 
-    const tempMessage: SelectMessage = {
-      id: Date.now(),
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      deleted_at: null,
-      sender: authUser,
-      type: newMsg.type,
-      chat_id: newMsg.chat_id,
-      sender_id: newMsg.sender_id,
-      message: newMsg.message
-    }
+    // The temporary message logic is now REMOVED as the message will come 
+    // back via the Pusher subscription after the server action successfully 
+    // creates and broadcasts it. This ensures the message only appears if 
+    // the server action succeeds, preventing desync.
 
+    // Update chat list optimistically before calling the server action
     setMyChats((prevChats) =>
       prevChats.map((chat) =>
         chat.id === currentChat.id
@@ -354,10 +331,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       )
     )
     setNewMessage("")
+    // This server action will now handle Pusher trigger for both 
+    // "new-message" on the chat channel and "chat-update" on user channels.
     await addMessageToChat(newMsg, currentSpace?.id)
   }
 
   return (
+    // ... (The rest of the component JSX remains the same)
     <div className="flex h-[calc(100vh-7rem)] gap-4">
       {/* Contacts list - visible on desktop, hidden on mobile */}
       <Card className="w-80 flex-shrink-0 border-r hidden md:flex md:flex-col h-full">

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -148,6 +148,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
     chatStore.isMobileMenuOpen
   )
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const initialChatLoadRef = useRef<boolean>(true)
   const [currentChat, setCurrentChat] = useAtom(chatStore.currentChat)
   const [switchedChat, setSwitchedChat] = useAtom(chatStore.switchedChat)
   const [myChats, setMyChats] = useAtom(chatStore.myChats)
@@ -172,7 +173,10 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
   useEffect(() => {
     setCurrentChat(currentChatSSR || null)
     setMyChats(allChatsSSR || [])
-    setMessages(currentChatSSR?.messages || [])
+    initialChatLoadRef.current = true
+    const initialMessages = currentChatSSR?.messages || []
+
+    setMessages(initialMessages)
     scrollToBottom()
     return () => {
       setCurrentChat(null)
@@ -180,10 +184,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
       setMessages([])
     }
   }, [])
-
   const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
-  }, [messages])
+    const behavior: ScrollBehavior = initialChatLoadRef.current
+      ? "auto"
+      : "smooth"
+    messagesEndRef.current?.scrollIntoView({ behavior })
+    initialChatLoadRef.current = false
+  }, [])
 
   useEffect(() => {
     if (!currentChat || !authUser) return
@@ -243,6 +250,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
    * @returns {Promise<void>} A promise that resolves when the chat has been switched.
    */
   const handleChatSwitch = async (chatId: number) => {
+    initialChatLoadRef.current = true
     const newSwitchedChat = await fetchChatWithMessages(chatId)
     if (newSwitchedChat && newSwitchedChat.data) {
       setCurrentChat(newSwitchedChat.data)

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -348,8 +348,8 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
           ? {
               ...chat,
               last_message: newMsg.message,
-              last_message_at: new Date().toISOString(),
-              updated_at: new Date().toISOString(),
+              last_message_at: moment().toISOString(),
+              updated_at: moment().toISOString(),
               unread_count: 0
             }
           : chat

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
@@ -61,10 +61,27 @@ function SprintBoardCard({
     useServerAction(GetSprintTasksAction)
 
   useEffect(() => {
-    if (tasks.length > 0) {
-      setFilteredTasks(tasks.filter((task) => task.sprint_id === sprint.id))
+    if (!sprint.id) return
+
+    if (filters && tasks?.length > 0) {
+      const filtered = tasks.filter((t) => {
+        return (
+          t?.sprint_id === sprint.id &&
+          (!filters.priority?.length ||
+            filters.priority.includes(t.task_priority)) &&
+          (!filters.type?.length || filters.type.includes(t.task_type)) &&
+          (!filters.status?.length ||
+            filters.status.includes(t.status_id || "")) &&
+          (!filters.assignee?.length ||
+            filters.assignee.includes(t.assign_to || ""))
+        )
+      })
+
+      setFilteredTasks(filtered)
+    } else if (tasks?.length > 0) {
+      setFilteredTasks(tasks.filter((t) => t?.sprint_id === sprint.id))
     }
-  }, [tasks])
+  }, [tasks, sprint.id, filters])
 
   useEffect(() => {
     const getTask = async () => {

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintCard.tsx
@@ -84,12 +84,27 @@ export default function SprintCardPage({
   ])
 
   useEffect(() => {
-    if (tasks?.length > 0 && sprint.id) {
-      setFilteredTasks(
-        tasks?.filter((t) => t?.sprint_id && t.sprint_id === sprint.id)
-      )
+    if (!sprint.id) return
+
+    if (filters && tasks?.length > 0) {
+      const filtered = tasks.filter((t) => {
+        return (
+          t?.sprint_id === sprint.id &&
+          (!filters.priority?.length ||
+            filters.priority.includes(t.task_priority)) &&
+          (!filters.type?.length || filters.type.includes(t.task_type)) &&
+          (!filters.status?.length ||
+            filters.status.includes(t.status_id || "")) &&
+          (!filters.assignee?.length ||
+            filters.assignee.includes(t.assign_to || ""))
+        )
+      })
+
+      setFilteredTasks(filtered)
+    } else if (tasks?.length > 0) {
+      setFilteredTasks(tasks.filter((t) => t?.sprint_id === sprint.id))
     }
-  }, [tasks, sprint.id])
+  }, [tasks, sprint.id, filters])
 
   // PERMISSIONS INITATE
   const { permissionChecker } = usePermissionChecker(

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
@@ -92,15 +92,8 @@ export function SprintManagement() {
   useEffect(() => {
     if (projectId && sprintList.length > 0 && tasks.length === 0) {
       fetchTasks()
-      console.log("Fetching tasks after update...")
     }
   }, [projectId, sprintList])
-
-  useEffect(() => {
-    if (tasks.length > 0) {
-      console.log("Tasks updated:", tasks)
-    }
-  }, [tasks])
 
   useEffect(() => {
     if (tasks.length > 0) {

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement.tsx
@@ -92,8 +92,15 @@ export function SprintManagement() {
   useEffect(() => {
     if (projectId && sprintList.length > 0 && tasks.length === 0) {
       fetchTasks()
+      console.log("Fetching tasks after update...")
     }
   }, [projectId, sprintList])
+
+  useEffect(() => {
+    if (tasks.length > 0) {
+      console.log("Tasks updated:", tasks)
+    }
+  }, [tasks])
 
   useEffect(() => {
     if (tasks.length > 0) {

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -505,6 +505,7 @@ export default function TaskForm({
                         onChange={field.onChange}
                         image_uploading={true}
                         editable={isEditable}
+                        limit={2000}
                       />
                     ) : (
                       <div

--- a/src/components/Dashboard/posts/create-post-form.tsx
+++ b/src/components/Dashboard/posts/create-post-form.tsx
@@ -195,6 +195,7 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
             title: "Error",
             description: "Error creating post please try again!"
           })
+          return
         }
       } else if (newPost.type === PostType.poll) {
         let linkedHashtags
@@ -251,6 +252,7 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
             title: "Error",
             description: "Error creating post please try again!"
           })
+          return
         }
       } else if (
         newPost.type === PostType.file ||
@@ -336,6 +338,7 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
             title: "Error",
             description: "Error creating post please try again!"
           })
+          return
         }
       }
       setHashtags([])
@@ -348,7 +351,10 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
           title: "Posted!",
           duration: 3000
         })
+
+        setShowCard(false)
       }
+
       setNewPost({
         content: "",
         hashtags: []

--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -181,8 +181,6 @@ export default function RichTextEditor({
     onUpdate({ editor }) {
       const html = editor.getHTML()
       if (onChange) {
-        console.log("Editor HTML:", html)
-        console.log("Editor isContentEmpty:", isContentEmpty(html))
         onChange(isContentEmpty(html) ? "" : html)
       }
     }

--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -97,6 +97,15 @@ export default function RichTextEditor({
     }
   })
 
+  const isContentEmpty = (html: string) => {
+    if (!html) return true
+    const text = html
+      .replace(/<[^>]*>/g, "")
+      .replace(/&nbsp;/g, "")
+      .trim()
+    return text === ""
+  }
+
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -172,7 +181,9 @@ export default function RichTextEditor({
     onUpdate({ editor }) {
       const html = editor.getHTML()
       if (onChange) {
-        onChange(html)
+        console.log("Editor HTML:", html)
+        console.log("Editor isContentEmpty:", isContentEmpty(html))
+        onChange(isContentEmpty(html) ? "" : html)
       }
     }
   })

--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -36,21 +36,21 @@ import { Image as ImageIcon } from "lucide-react"
 import { AddImageToTaskAction } from "@/src/server-actions/Tasks/Task"
 import Loader from "./Loader/Loader"
 import { LoaderSizes } from "./types/loader-types"
-import type { Editor as TiptapEditor } from "@tiptap/core"
 
 interface RichTextEditorProps {
   value?: string
   onChange?: (content: string) => void
   image_uploading?: boolean
   editable?: boolean
+  limit?: number
 }
 
-const limit = 1000
 export default function RichTextEditor({
   value,
   onChange,
   image_uploading,
-  editable
+  editable,
+  limit = 1000
 }: RichTextEditorProps) {
   const [linkUrl, setLinkUrl] = useState("")
   const [showLinkInput, setShowLinkInput] = useState(false)

--- a/src/db/data-access/chat/query.ts
+++ b/src/db/data-access/chat/query.ts
@@ -7,6 +7,7 @@ import {
   inArray,
   like,
   or,
+  sql,
   SQLWrapper
 } from "drizzle-orm"
 import { db } from "../.."
@@ -502,6 +503,44 @@ export const getExistingSingleChat = async (
     })
   } catch (error: any) {
     console.log(error.message, "error")
+    throw new Error(error.message)
+  }
+}
+
+export const getExistingGroupName = async (
+  chatName: string,
+  space_id?: string
+) => {
+  try {
+    if (!space_id) {
+      return undefined
+    }
+
+    const existingChat = await db.query.chatsTable.findFirst({
+      where: and(
+        eq(chatsTable.is_group, 1),
+        eq(chatsTable.name, chatName),
+
+        inArray(
+          chatsTable.id,
+          sql`${db
+            .select({ chat_id: SpaceChatsTable.chat_id })
+            .from(SpaceChatsTable)
+            .where(eq(SpaceChatsTable.space_id, space_id))}`
+        )
+      ),
+      with: {
+        users: {
+          with: {
+            user: true
+          }
+        }
+      }
+    })
+
+    return existingChat
+  } catch (error: any) {
+    console.error("Error during group name check:", error.message)
     throw new Error(error.message)
   }
 }

--- a/src/db/data-access/chat/query.ts
+++ b/src/db/data-access/chat/query.ts
@@ -164,7 +164,7 @@ export const GetChats = async (
             ? eq(chatsTable.is_group, 0)
             : undefined
         ),
-      orderBy: (chatsTable) => desc(chatsTable.updated_at),
+      orderBy: (chatsTable) => desc(chatsTable.created_at),
       with: {
         users: {
           with: {

--- a/src/db/data-access/chat/query.ts
+++ b/src/db/data-access/chat/query.ts
@@ -20,6 +20,7 @@ import {
   usersTable
 } from "../../schema"
 import { randomUUID } from "crypto"
+import { slugify } from "@/src/utils/helpers"
 
 export const CreatePrivateChat = async (
   user_id: string,
@@ -83,6 +84,7 @@ export const CreateGroupChat = async (
         type: space_id ? "space" : "open",
         name: chatName,
         channel_id: realtimeChannelId,
+        chat_slug: slugify(chatName),
         is_group: 1
       })
       .returning()
@@ -515,11 +517,11 @@ export const getExistingGroupName = async (
     if (!space_id) {
       return undefined
     }
-
+    const chatNamePattern = slugify(chatName);
     const existingChat = await db.query.chatsTable.findFirst({
       where: and(
         eq(chatsTable.is_group, 1),
-        eq(chatsTable.name, chatName),
+        eq(chatsTable.chat_slug, chatNamePattern),
 
         inArray(
           chatsTable.id,

--- a/src/db/data-access/chat/query.ts
+++ b/src/db/data-access/chat/query.ts
@@ -164,7 +164,7 @@ export const GetChats = async (
             ? eq(chatsTable.is_group, 0)
             : undefined
         ),
-      orderBy: (chatsTable) => desc(chatsTable.created_at),
+      orderBy: (chatsTable) => desc(chatsTable.updated_at),
       with: {
         users: {
           with: {

--- a/src/db/seeds/ChatSlugCorrectionSyncSeed.ts
+++ b/src/db/seeds/ChatSlugCorrectionSyncSeed.ts
@@ -1,0 +1,35 @@
+import { sql } from "drizzle-orm"
+import { db } from ".."
+import { chatsTable } from "../schema"
+import { slugify } from "@/src/utils/helpers"
+
+export const ChatSlugCorrectionSyncSeed = async () => {
+  return await db.transaction(async (tx) => {
+    try {
+      // Fetch all chat records
+      const chats = await tx.select().from(chatsTable)
+      
+      console.log(`📊 Found ${chats.length} chats to process`)
+      
+      // Update each chat with slugified name
+      for (const chat of chats) {
+        if (chat.name) {
+          const slug = slugify(chat.name)
+          
+          await tx
+            .update(chatsTable)
+            .set({ chat_slug: slug })
+            .where(sql`${chatsTable.id} = ${chat.id}`)
+        }
+      }
+      
+      console.log("✅ Chat slugs updated successfully")
+      
+    } catch (e) {
+      console.error(e)
+      tx.rollback()
+      console.log("❌ Error updating chat slugs")
+      process.exit(1)
+    }
+  })
+}

--- a/src/db/seeds/EmailTemplatesSeed.ts
+++ b/src/db/seeds/EmailTemplatesSeed.ts
@@ -58,6 +58,3 @@ export const EmailTemplatesSeed = async () => {
     }
   })
 }
-
-// You can call the function directly if you want this file to be executable
-EmailTemplatesSeed()

--- a/src/db/seeds/index.ts
+++ b/src/db/seeds/index.ts
@@ -12,6 +12,7 @@ import { SyncRolePermissionsSeeder } from "./SyncScopedPermissions"
 import { siteSettingsSeed } from "./SiteSettingsSeed"
 import { UpdateRoleTable } from "./UpdateRolesTable"
 import { EmailTemplatesSeed } from "./EmailTemplatesSeed"
+import { ChatSlugCorrectionSyncSeed } from "./ChatSlugCorrectionSyncSeed"
 
 const SEEDERS: Record<string, () => Promise<void>> = {
   FeatureSeed,
@@ -27,7 +28,8 @@ const SEEDERS: Record<string, () => Promise<void>> = {
   CheckRolePermissionMismatch,
   SyncRolePermissionsSeeder,
   siteSettingsSeed,
-  EmailTemplatesSeed
+  EmailTemplatesSeed,
+  ChatSlugCorrectionSyncSeed
 }
 
 async function runSeeders() {
@@ -40,7 +42,8 @@ async function runSeeders() {
       "NewTagsSeed",
       "CheckRolePermissionMismatch",
       "SyncRolePermissionsSeeder",
-      "EmailTemplatesSeed"
+      "EmailTemplatesSeed",
+      "ChatSlugCorrectionSyncSeed"
     ]
 
     const seederNames =

--- a/src/server-actions/Chat/Chat.ts
+++ b/src/server-actions/Chat/Chat.ts
@@ -15,9 +15,7 @@ import { CreateServerAction } from ".."
 import { InsertMessage } from "@/src/db/schema"
 import { AuthUserAction } from "../User/AuthUserAction"
 import { createChatMessage } from "@/src/db/data-access/chat/message/query"
-// REMOVED: import { AblyClientRest } from "@/src/services/realtime/AblyClient" // Removed Ably Rest Client
 import pusherServer from "@/src/services/realtime/pusherServer" // Added Pusher Server Client
-// REMOVED: import pusherClient from "@/src/services/realtime/PusherClient" // Not needed on server
 import { GetSpaceById } from "@/src/db/data-access/spaces/query"
 import {
   SendChatNotification,

--- a/src/server-actions/Chat/Chat.ts
+++ b/src/server-actions/Chat/Chat.ts
@@ -9,7 +9,8 @@ import {
   GetMutualChat,
   GetChats,
   updateLastChatMessage,
-  getExistingSingleChat
+  getExistingSingleChat,
+  getExistingGroupName
 } from "@/src/db/data-access/chat/query"
 import { CreateServerAction } from ".."
 import { InsertMessage } from "@/src/db/schema"
@@ -83,6 +84,17 @@ export const CreateGroupChatAction = CreateServerAction(
   true,
   async (userIds: string[], chatName: string, space_id?: string) => {
     try {
+      if (space_id) {
+        const existingChat = await getExistingGroupName(chatName, space_id)
+
+        if (existingChat) {
+          return {
+            success: false,
+            error:
+              "A group with this name already exists in this space. Please choose a different name."
+          }
+        }
+      }
       const authUser = await AuthUserAction()
       const space = await GetSpaceById(space_id || "")
 

--- a/src/server-actions/Chat/Chat.ts
+++ b/src/server-actions/Chat/Chat.ts
@@ -87,7 +87,7 @@ export const CreateGroupChatAction = CreateServerAction(
       if (space_id) {
         const existingChat = await getExistingGroupName(chatName, space_id)
 
-        if (existingChat) {
+        if (existingChat?.name?.toLowerCase() ==chatName.toLocaleLowerCase()) {
           return {
             success: false,
             error:

--- a/src/server-actions/Chat/Chat.ts
+++ b/src/server-actions/Chat/Chat.ts
@@ -15,7 +15,9 @@ import { CreateServerAction } from ".."
 import { InsertMessage } from "@/src/db/schema"
 import { AuthUserAction } from "../User/AuthUserAction"
 import { createChatMessage } from "@/src/db/data-access/chat/message/query"
-import { AblyClientRest } from "@/src/services/realtime/AblyClient"
+// REMOVED: import { AblyClientRest } from "@/src/services/realtime/AblyClient" // Removed Ably Rest Client
+import pusherServer from "@/src/services/realtime/pusherServer" // Added Pusher Server Client
+// REMOVED: import pusherClient from "@/src/services/realtime/PusherClient" // Not needed on server
 import { GetSpaceById } from "@/src/db/data-access/spaces/query"
 import {
   SendChatNotification,
@@ -54,15 +56,17 @@ export const CreatePrivateChatAction = CreateServerAction(
 
       const chatMembers = newChat.users
 
+      // CONVERTED: Ably publish to Pusher trigger
       for (const member of chatMembers) {
-        const userChannel = AblyClientRest.channels.get(
-          `user:${member.user_id}`
+        await pusherServer.trigger(
+          `private-user-${member.user_id}`, // Pusher user channel convention
+          "chat-created",
+          {
+            newChat,
+            initiatorId: user_id,
+            spaceId: space_id
+          }
         )
-        await userChannel.publish("chat-created", {
-          newChat,
-          initiatorId: user_id,
-          spaceId: space_id
-        })
       }
 
       await SendChatNotification(NotificationEvent.CHAT_INVITE, newChat, space)
@@ -95,18 +99,19 @@ export const CreateGroupChatAction = CreateServerAction(
       // Get the list of users in the newly created chat
       const chatUsers = chat.users?.map((userChat) => userChat.user) || []
 
-      // Loop through each user and publish the "chat-created" event to their channel
+      // CONVERTED: Ably publish to Pusher trigger
       for (const user of chatUsers) {
         if (!user?.unique_id) continue
-        const userChannel = AblyClientRest.channels.get(
-          `user:${user.unique_id}`
+        
+        await pusherServer.trigger(
+          `private-user-${user.unique_id}`, // Pusher user channel convention
+          "chat-created",
+          {
+            newChat: chat,
+            initiatorId: authUser.unique_id,
+            spaceId: space_id
+          }
         )
-
-        await userChannel.publish("chat-created", {
-          newChat: chat,
-          initiatorId: authUser.unique_id,
-          spaceId: space_id
-        })
       }
 
       await SendChatNotification(NotificationEvent.CHAT_INVITE, chat, space)
@@ -199,26 +204,30 @@ export const AddMessageToChatAction = CreateServerAction(
           }
           // const channelHash = ChatChannelHash(updatedChat.channel_id)
 
-          // send message to channel
-
-          const realtimeChannel = AblyClientRest.channels.get(
-            updatedChat.channel_id
+          // CONVERTED: Ably publish to Pusher trigger for the message itself
+          await pusherServer.trigger(
+            `private-chat-${updatedChat.id}`, // Pusher chat channel convention
+            "new-message", // Event name for new messages
+            { message: newMessage } // The new message data
           )
-          await realtimeChannel.publish("message", newMessage)
 
           const chatUsers = updatedChat.users
 
+          // CONVERTED: Ably publish to Pusher trigger for chat list update
           for (const userChat of chatUsers) {
             const userId = userChat.user_id
 
             if (userId !== authUser.unique_id) {
-              const userNotificationChannel = AblyClientRest.channels.get(
-                `user:${userId}`
+              await pusherServer.trigger(
+                `private-user-${userId}`, // Pusher user channel convention
+                "chat-update", // Event name for chat list updates
+                {
+                  update: { // Pusher data structure wrapper
+                    chatId: updatedChat.id,
+                    lastMessage: newMessage.message
+                  }
+                }
               )
-              await userNotificationChannel.publish("chat-update", {
-                chatId: updatedChat.id,
-                lastMessage: newMessage.message
-              })
             }
           }
 

--- a/src/services/notifications/Chat/utils.ts
+++ b/src/services/notifications/Chat/utils.ts
@@ -109,16 +109,22 @@ export const SendMessageNotification = async (
         )
         .map((userId) => userId)
 
+    const notificationPayload: NotificationPayload = {
+      receivers: nonPresentReciversIds || [],
+      template: {
+        title: `Spark- ${authUser.first_name} ${authUser.last_name} sent you a message`,
+        body: message.last_message || "",
+        deep_link: createAbsoluteUrl(CTALink),
+        icon: authUser.profile_url || ""
+      }
+    }
+
     if (nonPresentReciversIds?.length && nonPresentReciversIds.length > 0) {
       // Only send push if user is NOT present
-      await sendPushNotification({
-        receivers: nonPresentReciversIds,
-        template: {
-          title: `Spark- ${authUser.first_name} ${authUser.last_name} sent you a message`,
-          body: message.last_message || "",
-          deep_link: createAbsoluteUrl(CTALink),
-          icon: authUser.profile_url || ""
-        }
+      await sendPushNotification(notificationPayload)
+      await SendSystemNotification({
+        ...notificationPayload,
+        user_id: authUser.unique_id
       })
     }
   } catch (error) {


### PR DESCRIPTION
Tickets:
SW-2 : Restrict Duplicate Group Names
SW-9 : Duplicate file names allowed in the same folder
SW-18 : Messages scroll down from the start when opening chat
SW-33 : Able to Add Empty Comments Within Tasks
SW-155 : Change the realtime lib from Ably to pusher
SW-156 : Show system notification only when user is not active in chat
SW-17: truncate and fixed folder name
SW-25: close the post creation modal 
SW-154: Filters reset after creating or updating a task in Board and Sprint views
SW-152: increase task description character limit
SW-23: implement chat list order on new message

Notes:
have one seeder ->  npm run db:seed ChatSlugCorrectionSyncSeed         
