### PR TITLE
Feature/SW-25 close the post creation modal

### DIFF
--- a/src/components/Dashboard/posts/create-post-form.tsx
+++ b/src/components/Dashboard/posts/create-post-form.tsx
@@ -195,6 +195,7 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
             title: "Error",
             description: "Error creating post please try again!"
           })
+          return
         }
       } else if (newPost.type === PostType.poll) {
         let linkedHashtags
@@ -251,6 +252,7 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
             title: "Error",
             description: "Error creating post please try again!"
           })
+          return
         }
       } else if (
         newPost.type === PostType.file ||
@@ -336,6 +338,7 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
             title: "Error",
             description: "Error creating post please try again!"
           })
+          return
         }
       }
       setHashtags([])
@@ -348,7 +351,10 @@ const CreatePostForm: React.FC<Props> = ({ variant = "posts" }) => {
           title: "Posted!",
           duration: 3000
         })
+
+        setShowCard(false)
       }
+
       setNewPost({
         content: "",
         hashtags: []


### PR DESCRIPTION
Steps to Reproduce:





Navigate to the Posts section.



Click on Add Post.



Select any post type tab — Text, Image, Poll, or File.



Populate the post section.



Click on the Post button.

Actual Result:

After clicking Post, the Create a Post section remains visible and does not close automatically. The form appears stuck and requires the user to manually close it.



Expected Result:

After posting successfully, the Create a Post modal should close automatically, and the user should be redirected to the main Posts feed, where the newly added post (text, image, poll, or file) appears instantly.

Fixed: now post section will be close after post creation 