### PR TITLE
SW-40 Fix: Assign To dropdown not scrollable

### DIFF
--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -17,6 +17,7 @@ import Loader from "../common/Loader/Loader"
 import { Textarea } from "./textarea"
 import { Badge } from "./badge"
 import { CircleMinus, Cross, CrossIcon } from "lucide-react"
+import { ScrollArea } from "./scroll-area"
 
 export type MultiSelectOption = { label: string; value: string }
 
@@ -115,38 +116,50 @@ export default function MultiSelect({
               <CommandEmpty>No results found.</CommandEmpty>
             )}
             {options.length > 0 && (
-              <CommandGroup>
-                {hasAnySelected ? (
-                  <CommandItem
-                    onSelect={deselectAll}
-                    className="text-muted-foreground"
-                  >
-                    <Checkbox checked={hasAnySelected} className="mr-2" />
-                    Deselect All
-                  </CommandItem>
-                ) : (
-                  <CommandItem
-                    onSelect={selectAll}
-                    className="text-muted-foreground"
-                  >
-                    <Checkbox checked={false} className="mr-2" />
-                    Select All
-                  </CommandItem>
-                )}
-                {options.map((option) => (
-                  <CommandItem
-                    key={option.value}
-                    onSelect={() => toggleOption(option)}
-                  >
-                    <Checkbox
-                      checked={selectedValues.includes(option.value)}
-                      onCheckedChange={() => toggleOption(option)}
-                      className="mr-2"
-                    />
-                    {option.label}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+              <ScrollArea
+                className="max-h-[220px]"
+                // mouse wheel / touchpad wheel (including two-finger)
+                onWheel={(e) => {
+                  // allow native scrolling inside this div even if children try to capture events
+                  const el = e.currentTarget as HTMLDivElement
+                  // scroll by the wheel delta
+                  el.scrollTop += e.deltaY
+                  // do not call preventDefault — just let this handler move the scroll
+                }}
+              >
+                <CommandGroup>
+                  {hasAnySelected ? (
+                    <CommandItem
+                      onSelect={deselectAll}
+                      className="text-muted-foreground"
+                    >
+                      <Checkbox checked={hasAnySelected} className="mr-2" />
+                      Deselect All
+                    </CommandItem>
+                  ) : (
+                    <CommandItem
+                      onSelect={selectAll}
+                      className="text-muted-foreground"
+                    >
+                      <Checkbox checked={false} className="mr-2" />
+                      Select All
+                    </CommandItem>
+                  )}
+                  {options.map((option) => (
+                    <CommandItem
+                      key={option.value}
+                      onSelect={() => toggleOption(option)}
+                    >
+                      <Checkbox
+                        checked={selectedValues.includes(option.value)}
+                        onCheckedChange={() => toggleOption(option)}
+                        className="mr-2"
+                      />
+                      {option.label}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </ScrollArea>
             )}
           </Command>
         </PopoverContent>


### PR DESCRIPTION
### Issue
In the Backlog → Add Item flow, the "Assign To" dropdown list is not scrollable. When a community has more than 11–12 team members, the dropdown extends beyond the visible screen area, preventing users from viewing or selecting members at the bottom of the list.

### Steps to Reproduce
1. Open any community → channel → space with more than 11–12 members.
2. Navigate to Project Management → Project → Backlog.
3. Click **Add Item**.
4. Fill in the required fields: title, Issue Type, Priority.
5. Open the **Assign To** dropdown.
6. Try scrolling to the bottom of the members list.

### Actual Result
- The dropdown is not scrollable.
- Lower items move out of the visible screen area and cannot be selected.

### Expected Result
- The “Assign To” dropdown should be scrollable.
- Users should be able to view and select all team members, including those not initially visible.

### Fix Implemented
- Added scrollable container with height constraints to the assignee list.

### Testing
- Tested with communities having 5, 12, 20+ team members.
- Confirmed smooth scroll and ability to select any member.
