### PR TITLE
SW-37-fixed scrollbar position

### DIFF
--- a/src/app/(dashboard)/project/[id]/(project-layout)/layout.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/layout.tsx
@@ -56,7 +56,13 @@ async function layout({ children, params }: Props) {
 
           <div className="col-span-10 overflow-hidden">
             <div className="grid grid-cols-1 h-full">
-              <ScrollArea className="min-h-full px-4">{children}</ScrollArea>
+              {/* preserveKey stable across modal route changes so scroll doesn't reset */}
+              <ScrollArea
+                preserveKey={`project:${projectId}:board-scroll`}
+                className="min-h-full px-4"
+              >
+                {children}
+              </ScrollArea>
             </div>
           </div>
         </>

--- a/src/app/(dashboard)/project/[id]/(project-layout)/layout.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/layout.tsx
@@ -56,13 +56,7 @@ async function layout({ children, params }: Props) {
 
           <div className="col-span-10 overflow-hidden">
             <div className="grid grid-cols-1 h-full">
-              {/* preserveKey stable across modal route changes so scroll doesn't reset */}
-              <ScrollArea
-                preserveKey={`project:${projectId}:board-scroll`}
-                className="min-h-full px-4"
-              >
-                {children}
-              </ScrollArea>
+              <ScrollArea className="min-h-full px-4">{children}</ScrollArea>
             </div>
           </div>
         </>

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
@@ -165,7 +165,7 @@ function SprintBoardCard({ sprint, tasks, onOpenTask }: Props) {
         <CardHeader className="pb-2">
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
             <div>
-              {/* <CardTitle>{sprint.title}</CardTitle> */}
+              <CardTitle>{sprint.title}</CardTitle>
               <CardDescription>
                 {new Date(sprint.start_date).toLocaleDateString()} -{" "}
                 {new Date(sprint.end_date).toLocaleDateString()}

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
@@ -38,20 +38,11 @@ import { Skeleton } from "@/src/components/ui/skeleton"
 interface Props {
   sprint: SelectSprint
   tasks: SelectTask[]
-  isTaskModalOpen: boolean
-  setIsTaskModalOpen: Dispatch<SetStateAction<boolean>>
-  selectedTask: SelectTask | null
-  setSelectedTask: Dispatch<SetStateAction<SelectTask | null>>
+  // parent will open modal and set selected task so it can capture scroll before open
+  onOpenTask?: (task: SelectTask) => void
 }
 
-function SprintBoardCard({
-  sprint,
-  tasks,
-  isTaskModalOpen,
-  setIsTaskModalOpen,
-  selectedTask,
-  setSelectedTask
-}: Props) {
+function SprintBoardCard({ sprint, tasks, onOpenTask }: Props) {
   const projectStatusList = useAtomValue(projectStore.projectStatusList)
   const [filteredTasks, setFilteredTasks] = useState<SelectTask[]>([])
   const [filters, setFilters] = useState<TaskFiltersType | null>(null)
@@ -95,8 +86,7 @@ function SprintBoardCard({
   ])
 
   function handleOnTaskClick(task: SelectTask) {
-    setSelectedTask(task)
-    setIsTaskModalOpen(true)
+    onOpenTask?.(task)
   }
 
   function HandleTaskFilters(filters: TaskFiltersType) {
@@ -175,7 +165,7 @@ function SprintBoardCard({
         <CardHeader className="pb-2">
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
             <div>
-              <CardTitle>{sprint.title}</CardTitle>
+              {/* <CardTitle>{sprint.title}</CardTitle> */}
               <CardDescription>
                 {new Date(sprint.start_date).toLocaleDateString()} -{" "}
                 {new Date(sprint.end_date).toLocaleDateString()}

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
@@ -6,7 +6,7 @@ import { GetSprintAction } from "@/src/server-actions/Sprint/sprint"
 import { useAtom, useAtomValue } from "jotai"
 import { sprintStore } from "@/src/store/sprint/sprintsStore"
 import Loader from "@/src/components/common/Loader/Loader"
-import { useEffect, useState } from "react"
+import { useEffect, useState, useRef } from "react"
 import SprintBoardCard from "./SprintBoardCard"
 import { projectStore } from "@/src/store/project/projectStore"
 import StatusRequiredDialog from "../../StatusRequiredDialog"
@@ -20,8 +20,12 @@ import pusherClient from "@/src/services/realtime/PusherClient"
 import { userStore } from "@/src/store/user/userStore"
 import { taskStore } from "@/src/store/tasks/taskStore"
 import { SprintStatus, TaskType } from "../../constants/projectManagment"
+import { createPortal } from "react-dom"
 
 function SprintBoard() {
+  const params = useParams()
+  const projectId = (params as { id?: string })?.id
+
   const [sprintList, setSprintList] = useAtom(sprintStore.sprints)
   const [getSprintLoading, , , GetSprints] = useServerAction(GetSprintAction)
 
@@ -37,8 +41,86 @@ function SprintBoard() {
   const authUser = useAtomValue(userStore.AuthUser)
   const pusherChannel = useAtomValue(projectStore.pusherChannel)
   const [isInitailDataLoad, setIsInitailDataLoad] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const boardRef = useRef<HTMLDivElement | null>(null)
+  const scrollContainerRef = useRef<HTMLElement | null>(null)
+  const savedScroll = useRef<number>(0)
 
-  const projectId = useParams().id as string
+  // mark client mounted so we can render modal portal
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // find scrollable viewport once mounted (try nearest to boardRef first)
+  useEffect(() => {
+    if (!mounted) return
+    const findScrollContainer = () => {
+      const nearest = (boardRef.current?.closest('[data-scrollable="true"]') ||
+        document.querySelector(
+          '[data-scrollable="true"]'
+        )) as HTMLElement | null
+      scrollContainerRef.current = nearest
+    }
+    findScrollContainer()
+    // also attempt again after a short delay in case layout changes
+    const t = window.setTimeout(findScrollContainer, 100)
+    return () => clearTimeout(t)
+  }, [mounted, boardRef.current])
+
+  // open handler: capture scroll before opening modal (synchronously)
+  function handleOpenTask(task: SelectTask) {
+    const sc =
+      (boardRef.current?.closest(
+        '[data-scrollable="true"]'
+      ) as HTMLElement | null) ||
+      (document.querySelector(
+        '[data-scrollable="true"]'
+      ) as HTMLElement | null) ||
+      scrollContainerRef.current
+    if (sc) savedScroll.current = sc.scrollTop || 0
+
+    // set selected task and open modal immediately
+    setSelectedTask(task)
+    setIsTaskModalOpen(true)
+  }
+
+  // lock body overflow while modal open to prevent layout shifts
+  useEffect(() => {
+    if (isTaskModalOpen) {
+      document.body.style.overflow = "hidden"
+    } else {
+      document.body.style.overflow = ""
+    }
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [isTaskModalOpen])
+
+  // restore scroll immediately when modal closes (no timers)
+  useEffect(() => {
+    if (isTaskModalOpen) return // skip while modal is open
+
+    // restore to exact saved position immediately
+    const sc =
+      (boardRef.current?.closest(
+        '[data-scrollable="true"]'
+      ) as HTMLElement | null) ||
+      (document.querySelector('[data-scrollable="true"]') as HTMLElement | null)
+
+    if (sc) {
+      console.log(`[SprintBoard] Restoring scroll to ${savedScroll.current}`)
+      sc.scrollTop = savedScroll.current
+
+      // safety: restore again after TaskModal effects settle
+      setTimeout(() => {
+        if (sc) {
+          sc.scrollTop = savedScroll.current
+        }
+      }, 10)
+    } else {
+      console.warn(`[SprintBoard] Could not find scroll container`)
+    }
+  }, [isTaskModalOpen])
 
   useEffect(() => {
     if (!pusherChannel || !authUser) return
@@ -146,41 +228,47 @@ function SprintBoard() {
 
   return projectStatusList.length > 0 ? (
     <>
-      {getSprintLoading ? (
-        <div className="flex items-center justify-center">
-          <Loader size={LoaderSizes.lg} />
-        </div>
-      ) : sprintList.length === 0 ? (
-        <NoDataCard
-          title="No Active Sprint"
-          description="There are no active sprints for this project. Create and active a new sprint to get started."
-          icon={<Kanban />}
-        />
-      ) : (
-        sprintList.map((sprint) => (
-          <SprintBoardCard
-            sprint={sprint}
-            key={sprint.id}
-            tasks={tasks}
-            isTaskModalOpen={isTaskModalOpen}
-            setIsTaskModalOpen={setIsTaskModalOpen}
-            selectedTask={selectedTask}
-            setSelectedTask={setSelectedTask}
+      <div ref={boardRef} className="h-full">
+        {getSprintLoading ? (
+          <div className="flex items-center justify-center">
+            <Loader size={LoaderSizes.lg} />
+          </div>
+        ) : sprintList.length === 0 ? (
+          <NoDataCard
+            title="No Active Sprint"
+            description="There are no active sprints for this project. Create and active a new sprint to get started."
+            icon={<Kanban />}
           />
-        ))
-      )}
+        ) : (
+          sprintList.map((sprint) => (
+            <SprintBoardCard
+              sprint={sprint}
+              key={sprint.id}
+              tasks={tasks}
+              onOpenTask={handleOpenTask}
+            />
+          ))
+        )}
+      </div>
 
-      <TaskModal
-        isReady={isInitailDataLoad}
-        isTaskModelOpen={isTaskModalOpen}
-        setIsTaskModelOpen={setIsTaskModalOpen}
-        selectedTask={selectedTask || undefined}
-        onUpdateComplete={(task: SelectTask) => {
-          setTasks((prev) => prev.map((t) => (t.id === task.id ? task : t)))
-          setSelectedTask(task)
-        }}
-        onSubTaskCreate={(task: SelectTask) => getTasks()}
-      />
+      {mounted
+        ? createPortal(
+            <TaskModal
+              isReady={isInitailDataLoad}
+              isTaskModelOpen={isTaskModalOpen}
+              setIsTaskModelOpen={setIsTaskModalOpen}
+              selectedTask={selectedTask || undefined}
+              onUpdateComplete={(task: SelectTask) => {
+                setTasks((prev) =>
+                  prev.map((t) => (t.id === task.id ? task : t))
+                )
+                setSelectedTask(task)
+              }}
+              onSubTaskCreate={(task: SelectTask) => getTasks()}
+            />,
+            document.body
+          )
+        : null}
     </>
   ) : (
     <StatusRequiredDialog openDialog={openDialog} />

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
@@ -46,12 +46,10 @@ function SprintBoard() {
   const scrollContainerRef = useRef<HTMLElement | null>(null)
   const savedScroll = useRef<number>(0)
 
-  // mark client mounted so we can render modal portal
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  // find scrollable viewport once mounted (try nearest to boardRef first)
   useEffect(() => {
     if (!mounted) return
     const findScrollContainer = () => {
@@ -62,12 +60,8 @@ function SprintBoard() {
       scrollContainerRef.current = nearest
     }
     findScrollContainer()
-    // also attempt again after a short delay in case layout changes
-    const t = window.setTimeout(findScrollContainer, 100)
-    return () => clearTimeout(t)
   }, [mounted, boardRef.current])
 
-  // open handler: capture scroll before opening modal (synchronously)
   function handleOpenTask(task: SelectTask) {
     const sc =
       (boardRef.current?.closest(
@@ -79,12 +73,10 @@ function SprintBoard() {
       scrollContainerRef.current
     if (sc) savedScroll.current = sc.scrollTop || 0
 
-    // set selected task and open modal immediately
     setSelectedTask(task)
     setIsTaskModalOpen(true)
   }
 
-  // lock body overflow while modal open to prevent layout shifts
   useEffect(() => {
     if (isTaskModalOpen) {
       document.body.style.overflow = "hidden"
@@ -96,11 +88,9 @@ function SprintBoard() {
     }
   }, [isTaskModalOpen])
 
-  // restore scroll immediately when modal closes (no timers)
   useEffect(() => {
-    if (isTaskModalOpen) return // skip while modal is open
+    if (isTaskModalOpen) return
 
-    // restore to exact saved position immediately
     const sc =
       (boardRef.current?.closest(
         '[data-scrollable="true"]'
@@ -108,17 +98,13 @@ function SprintBoard() {
       (document.querySelector('[data-scrollable="true"]') as HTMLElement | null)
 
     if (sc) {
-      console.log(`[SprintBoard] Restoring scroll to ${savedScroll.current}`)
       sc.scrollTop = savedScroll.current
 
-      // safety: restore again after TaskModal effects settle
       setTimeout(() => {
         if (sc) {
           sc.scrollTop = savedScroll.current
         }
       }, 10)
-    } else {
-      console.warn(`[SprintBoard] Could not find scroll container`)
     }
   }, [isTaskModalOpen])
 

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/index.tsx
@@ -20,7 +20,6 @@ import pusherClient from "@/src/services/realtime/PusherClient"
 import { userStore } from "@/src/store/user/userStore"
 import { taskStore } from "@/src/store/tasks/taskStore"
 import { SprintStatus, TaskType } from "../../constants/projectManagment"
-import { createPortal } from "react-dom"
 
 function SprintBoard() {
   const params = useParams()
@@ -41,26 +40,9 @@ function SprintBoard() {
   const authUser = useAtomValue(userStore.AuthUser)
   const pusherChannel = useAtomValue(projectStore.pusherChannel)
   const [isInitailDataLoad, setIsInitailDataLoad] = useState(false)
-  const [mounted, setMounted] = useState(false)
   const boardRef = useRef<HTMLDivElement | null>(null)
   const scrollContainerRef = useRef<HTMLElement | null>(null)
   const savedScroll = useRef<number>(0)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  useEffect(() => {
-    if (!mounted) return
-    const findScrollContainer = () => {
-      const nearest = (boardRef.current?.closest('[data-scrollable="true"]') ||
-        document.querySelector(
-          '[data-scrollable="true"]'
-        )) as HTMLElement | null
-      scrollContainerRef.current = nearest
-    }
-    findScrollContainer()
-  }, [mounted, boardRef.current])
 
   function handleOpenTask(task: SelectTask) {
     const sc =
@@ -76,17 +58,6 @@ function SprintBoard() {
     setSelectedTask(task)
     setIsTaskModalOpen(true)
   }
-
-  useEffect(() => {
-    if (isTaskModalOpen) {
-      document.body.style.overflow = "hidden"
-    } else {
-      document.body.style.overflow = ""
-    }
-    return () => {
-      document.body.style.overflow = ""
-    }
-  }, [isTaskModalOpen])
 
   useEffect(() => {
     if (isTaskModalOpen) return
@@ -237,24 +208,17 @@ function SprintBoard() {
         )}
       </div>
 
-      {mounted
-        ? createPortal(
-            <TaskModal
-              isReady={isInitailDataLoad}
-              isTaskModelOpen={isTaskModalOpen}
-              setIsTaskModelOpen={setIsTaskModalOpen}
-              selectedTask={selectedTask || undefined}
-              onUpdateComplete={(task: SelectTask) => {
-                setTasks((prev) =>
-                  prev.map((t) => (t.id === task.id ? task : t))
-                )
-                setSelectedTask(task)
-              }}
-              onSubTaskCreate={(task: SelectTask) => getTasks()}
-            />,
-            document.body
-          )
-        : null}
+      <TaskModal
+        isReady={isInitailDataLoad}
+        isTaskModelOpen={isTaskModalOpen}
+        setIsTaskModelOpen={setIsTaskModalOpen}
+        selectedTask={selectedTask || undefined}
+        onUpdateComplete={(task: SelectTask) => {
+          setTasks((prev) => prev.map((t) => (t.id === task.id ? task : t)))
+          setSelectedTask(task)
+        }}
+        onSubTaskCreate={(task: SelectTask) => getTasks()}
+      />
     </>
   ) : (
     <StatusRequiredDialog openDialog={openDialog} />

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintTasks.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintTasks.tsx
@@ -164,7 +164,7 @@ function SprintTasks({
     <>
       <div
         key={task.id}
-        className="grid grid-cols-12 gap-2 p-4 border-t items-center hover:bg-muted/50  transition delay-150 duration-300"
+        className="grid  grid-cols-12 gap-2 p-4 border-t items-center hover:bg-muted/50  transition delay-150 duration-300"
       >
         <div className="col-span-1">
           <TooltipProvider>

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
@@ -131,6 +131,14 @@ export const TaskModal = ({
         setInternalTask(undefined)
         setSelectedTask(null)
         setIsChanged(false)
+
+        const params = new URLSearchParams(searchParams.toString())
+        params.delete("task_id")
+
+        const newQuery = params.toString()
+        const newUrl = newQuery ? `${pathName}?${newQuery}` : pathName
+
+        router.replace(newUrl, { scroll: false })
       }
     })
 

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
@@ -131,13 +131,7 @@ export const TaskModal = ({
         setInternalTask(undefined)
         setSelectedTask(null)
         setIsChanged(false)
-
-        const newSearchParams = new URLSearchParams(searchParams.toString())
-        newSearchParams.delete("task_id")
-
-        setTimeout(() => {
-          router.push(`${pathName}?${newSearchParams.toString()}`)
-        }, 0)
+        // remove router.push to avoid layout remount on close
       }
     })
 

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskModal.tsx
@@ -131,7 +131,6 @@ export const TaskModal = ({
         setInternalTask(undefined)
         setSelectedTask(null)
         setIsChanged(false)
-        // remove router.push to avoid layout remount on close
       }
     })
 

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,26 +1,112 @@
 "use client"
-
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
-
 import { cn } from "@/src/lib/utils"
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn("relative overflow-hidden", className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-))
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    preserveKey?: string
+  }
+>(({ className, children, preserveKey, ...props }, ref) => {
+  const viewportRef = React.useRef<HTMLDivElement | null>(null)
+
+  const storageKey = React.useMemo(() => {
+    if (preserveKey) return `scroll:${preserveKey}`
+    if (typeof window === "undefined") return `scroll:unknown`
+    return `scroll:${window.location.pathname}${window.location.search}`
+  }, [preserveKey])
+
+  const lastSavedRef = React.useRef<{ top: number; left: number } | null>(null)
+  const saveTimeoutRef = React.useRef<number | null>(null)
+
+  // restore on mount (after paint)
+  React.useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(storageKey)
+      if (raw && viewportRef.current) {
+        const { top = 0, left = 0 } = JSON.parse(raw)
+        window.requestAnimationFrame(() => {
+          setTimeout(() => {
+            if (viewportRef.current) {
+              viewportRef.current.scrollTop = top
+              viewportRef.current.scrollLeft = left
+              lastSavedRef.current = { top, left }
+            }
+          }, 0)
+        })
+      }
+    } catch {
+      // ignore
+    }
+    // run only on mount/storageKey
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey])
+
+  // flush/save on unmount but avoid saving transient 0/0 that would overwrite a good value
+  React.useEffect(() => {
+    return () => {
+      try {
+        if (saveTimeoutRef.current) {
+          window.clearTimeout(saveTimeoutRef.current)
+          saveTimeoutRef.current = null
+        }
+        if (!viewportRef.current) return
+        const top = viewportRef.current.scrollTop
+        const left = viewportRef.current.scrollLeft
+        const prev = lastSavedRef.current
+        if (prev === null && top === 0 && left === 0) return
+        if (prev && prev.top === top && prev.left === left) return
+        sessionStorage.setItem(storageKey, JSON.stringify({ top, left }))
+        lastSavedRef.current = { top, left }
+      } catch {
+        // ignore
+      }
+    }
+  }, [storageKey])
+
+  const handleScroll = React.useCallback(() => {
+    try {
+      if (!viewportRef.current) return
+      if (saveTimeoutRef.current) {
+        window.clearTimeout(saveTimeoutRef.current)
+      }
+      saveTimeoutRef.current = window.setTimeout(() => {
+        try {
+          if (!viewportRef.current) return
+          const top = viewportRef.current.scrollTop
+          const left = viewportRef.current.scrollLeft
+          sessionStorage.setItem(storageKey, JSON.stringify({ top, left }))
+          lastSavedRef.current = { top, left }
+        } catch {
+          // ignore
+        }
+      }, 120) as unknown as number
+    } catch {
+      // ignore
+    }
+  }, [storageKey])
+
+  return (
+    <ScrollAreaPrimitive.Root
+      ref={ref}
+      className={cn("relative overflow-hidden", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
+        data-scrollable="true"
+        className="h-full w-full rounded-[inherit]"
+        onScroll={handleScroll}
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+})
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 
 const ScrollBar = React.forwardRef<


### PR DESCRIPTION
[SW-37](https://spark.etlonline.org/project/08ce22b9-6738-47dd-9acf-b544d832e04d/board?task_id=ef13bb0e-2028-4df8-ab37-80420065dd9b)

**Issue:**
When a task is opened and then closed, the screen automatically scrolls back to the top of the board, causing loss of the previous scroll position.

**Steps to Reproduce:**
Open any Community → Channel → Space.
Navigate to Project Management → Project → Board.
Scroll down the board to view tasks lower on the page.
Open any task from this position.
Close the task and observe the screen position.
**Expected Result:**
The screen should retain the user’s scroll position and remain at the same point where the task was opened.