### PR TITLE
SW-24 Feature: Allow Post Owner to Edit Published Posts

### DIFF
--- a/src/components/Dashboard/posts/post-menu.tsx
+++ b/src/components/Dashboard/posts/post-menu.tsx
@@ -14,6 +14,8 @@ import { useServerAction } from "@/src/hooks/useServerAction"
 import { userStore } from "@/src/store/user/userStore"
 import { SelectPost } from "@/src/db/schema"
 import { usePermissionChecker } from "@/src/hooks/usePermissionChecker"
+import UpdatePostModal from "./updatePostModal"
+import { useState } from "react"
 
 interface PostMenuProps {
   post: SelectPost
@@ -29,6 +31,7 @@ const PostMenu = ({ post, spaceId }: PostMenuProps) => {
     spaceId
   )
 
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const permissionNamespaceCreate = spaceId
     ? "space.posting.delete"
     : "posting.delete"
@@ -68,19 +71,35 @@ const PostMenu = ({ post, spaceId }: PostMenuProps) => {
 
   if (shouldShowDeleteButton) {
     return (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm">
-            <MoreVertical className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem className="text-destructive" onClick={handleDelete}>
-            <Trash className="mr-2 h-4 w-4" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm">
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="text-destructive"
+              onClick={handleDelete}
+            >
+              <Trash className="mr-2 h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+            {isPostOwner ? (
+              <DropdownMenuItem onClick={() => setIsEditModalOpen(true)}>
+                Edit Post
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <UpdatePostModal
+          selectedPost={post}
+          openDialog={isEditModalOpen}
+          setOpenDialog={setIsEditModalOpen}
+        />
+      </>
     )
   } else {
     // If no permission, return null (don't render anything)

--- a/src/components/Dashboard/posts/updatePostModal.tsx
+++ b/src/components/Dashboard/posts/updatePostModal.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from "../../ui/dialog"
+
+import { SelectPost } from "@/src/db/schema"
+import { useToast } from "@/src/hooks/use-toast"
+import { useServerAction } from "@/src/hooks/useServerAction"
+import {
+  LinkHashtagsToPostAction,
+  UnlinkHashtagsFromPostAction,
+  UpdatePostAction
+} from "@/src/server-actions/Post/Post"
+import { useSetAtom } from "jotai"
+import useHashtags from "../profile/hooks/useHashtags"
+import { Label } from "../../ui/label"
+import TagsInput from "../../TagsInput/TagsInput"
+import { Textarea } from "../../ui/textarea"
+import z from "zod"
+import { Controller, useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Button } from "../../ui/button"
+import { postStore } from "@/src/store/post/postStore"
+import { TagStatus } from "../../TagsInput/tags-input-types"
+import { PostType } from "./types/posts-types"
+
+interface UpdatePostModalProps {
+  selectedPost: SelectPost
+  openDialog: boolean
+  setOpenDialog: (open: boolean) => void
+  variant?: "posts" | "spaces"
+}
+
+const postContentZodSchema = z
+  .object({
+    content: z.string().optional(),
+    type: z
+      .enum([PostType.text, PostType.poll, PostType.file, PostType.image])
+      .optional()
+  })
+  .refine(
+    (data) => {
+      if (data.type === PostType.text || data.type === PostType.poll)
+        return !!data.content?.trim()
+      return true
+    },
+    {
+      message: "Post content cannot be empty",
+      path: ["content"]
+    }
+  )
+
+function UpdatePostModal({
+  selectedPost,
+  openDialog,
+  setOpenDialog,
+  variant = "posts"
+}: UpdatePostModalProps) {
+  const [postContent, setPostContent] = useState(selectedPost.content || "")
+  const setPost = useSetAtom(postStore.posts)
+
+  const [updatePostLoading, , , updatePost] = useServerAction(UpdatePostAction)
+  const [linkHashtagsToPostLoading, , , linkHashtagsToPost] = useServerAction(
+    LinkHashtagsToPostAction
+  )
+  const [unlinkHashtagsFromPostLoading, , , unlinkHashtagsFromPost] =
+    useServerAction(UnlinkHashtagsFromPostAction)
+
+  const form = useForm({
+    resolver: zodResolver(postContentZodSchema),
+    defaultValues: {
+      content: selectedPost.content || "",
+      type: selectedPost.type as PostType
+    }
+  })
+
+  const { toast } = useToast()
+
+  const [
+    hashtags,
+    setHashtags,
+    suggestions,
+    searchTagsForUserInput,
+    searchTagsLoading
+  ] = useHashtags()
+
+  useEffect(() => {
+    if (!selectedPost || !selectedPost.hashtags) return
+
+    form.setValue("content", selectedPost.content || "")
+
+    const formatted = selectedPost.hashtags.map((tag) => ({
+      id: tag.id,
+      name: tag.name,
+      status: TagStatus.selected,
+      count: tag.count || 0
+    }))
+
+    setHashtags(formatted)
+  }, [selectedPost])
+
+  const handleUpdatePost = async (data: any) => {
+    try {
+      const tagsAdded = hashtags.filter(
+        (t) =>
+          !t.deleted &&
+          !(selectedPost.hashtags ?? []).some(
+            (old) => old.name.toLowerCase() === t.name.toLowerCase()
+          )
+      )
+
+      const tagsRemoved = hashtags
+        .filter(
+          (t) =>
+            t.deleted === true &&
+            !hashtags.some(
+              (tag) =>
+                tag.name.toLowerCase() === t.name.toLowerCase() &&
+                tag.status === TagStatus.new
+            )
+        )
+        .map((t) => t.id)
+
+      // link tags
+      if (tagsAdded.length > 0) {
+        const linkTags = await linkHashtagsToPost(selectedPost.id, tagsAdded)
+        if (linkTags?.success && linkTags.data) {
+          const mapped = linkTags.data.map((t: any) => ({
+            id: t.id,
+            name: t.name,
+            status: TagStatus.selected,
+            count: t.count || 0
+          }))
+        }
+      }
+
+      // unlink tags
+      if (tagsRemoved.length > 0) {
+        const unlinkTags = await unlinkHashtagsFromPost(
+          selectedPost.id,
+          tagsRemoved as number[]
+        )
+      }
+
+      const updatedHashtags = [
+        ...(selectedPost.hashtags ?? []).filter(
+          (old) =>
+            !hashtags.some(
+              (t) =>
+                t.deleted && t.name.toLowerCase() === old.name.toLowerCase()
+            )
+        ),
+        ...hashtags.filter(
+          (t) =>
+            !t.deleted &&
+            !selectedPost.hashtags?.some(
+              (old) => old.name.toLowerCase() === t.name.toLowerCase()
+            )
+        )
+      ]
+
+      const newPostContent = await updatePost(selectedPost.id, data.content)
+
+      if (newPostContent?.success && newPostContent.data) {
+        setPost((posts) =>
+          posts.map((post) =>
+            post.id === selectedPost.id
+              ? ({
+                  ...post,
+                  content: newPostContent.data.content,
+                  hashtags: updatedHashtags
+                } as unknown as SelectPost)
+              : post
+          )
+        )
+
+        toast({ title: "Success", description: "Post updated successfully!" })
+
+        setOpenDialog(false)
+      }
+    } catch (error) {
+      console.error(error)
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Error Updating post please try again!"
+      })
+    }
+  }
+
+  const error = form.formState.errors
+
+  const loading =
+    updatePostLoading ||
+    linkHashtagsToPostLoading ||
+    unlinkHashtagsFromPostLoading
+
+  return (
+    <Dialog open={openDialog} onOpenChange={setOpenDialog}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Post</DialogTitle>
+          <DialogDescription>
+            Here you can edit your post details.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={form.handleSubmit(handleUpdatePost)}
+          className="flex flex-col gap-6"
+        >
+          <div>
+            <Label htmlFor="content">Content</Label>
+            <Controller
+              name="content"
+              defaultValue=""
+              control={form.control}
+              render={({ field }) => (
+                <div className="flex flex-col gap-2">
+                  <Textarea value={field.value} onChange={field.onChange} />
+                  <div className="text-red-500 text-sm text-left">
+                    {error.content?.message}
+                  </div>
+                </div>
+              )}
+            />
+            <div className="mt-2">
+              <Label htmlFor="hashtags">Hashtags</Label>
+              <TagsInput
+                autocomplete
+                tags={hashtags}
+                updateTags={setHashtags}
+                onChange={searchTagsForUserInput}
+                suggestions={suggestions}
+                loadingSuggestions={searchTagsLoading}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button loading={loading}>Update Post</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default UpdatePostModal

--- a/src/components/TagsInput/TagsInput.tsx
+++ b/src/components/TagsInput/TagsInput.tsx
@@ -236,7 +236,7 @@ const TagsInput: React.FC<TagsInputProps> = ({
 
   return (
     <div className="relative w-full">
-      <div className="flex flex-wrap gap-2 rounded-md border border-input bg-transparent focus-within:ring-1 focus-within:ring-ring">
+      <div className="flex flex-wrap gap-2 rounded-md border border-input bg-transparent focus-within:ring-1 focus-within:ring-ring p-2">
         {autocomplete
           ? (tags as Tag[]).map(
               (tag, i) =>

--- a/src/db/data-access/post/query.ts
+++ b/src/db/data-access/post/query.ts
@@ -36,6 +36,20 @@ export const CreatePost = async (post: InsertPost) => {
   return await db.insert(postsTable).values(post).returning()
 }
 
+export const UpdatePost = async (postId: string, content: string) => {
+  try {
+    const updatedPost = await db
+      .update(postsTable)
+      .set({ content })
+      .where(eq(postsTable.id, postId))
+      .returning()
+
+    return updatedPost[0]
+  } catch (error: any) {
+    throw new Error(error)
+  }
+}
+
 export const GetPostById = async (postId: string) => {
   try {
     return await db.query.postsTable.findFirst({
@@ -310,6 +324,24 @@ export const AddHashtagToPostLink = async (
       return { post_id: postId, hashtag_id: tag.id }
     })
   )
+}
+
+export const RemoveHashtagFromPostLink = async (
+  postId: string,
+  hashtagId: number[]
+) => {
+  try {
+    const removedHashtags = await db
+      .delete(postHashtagsTable)
+      .where(
+        and(
+          eq(postHashtagsTable.post_id, postId),
+          inArray(postHashtagsTable.hashtag_id, hashtagId)
+        )
+      )
+  } catch (error: any) {
+    throw new Error(error)
+  }
 }
 
 export const SearchHashtags = async (searchTerm: string) => {

--- a/src/server-actions/Post/Post.ts
+++ b/src/server-actions/Post/Post.ts
@@ -14,7 +14,9 @@ import {
   GetPosts,
   GetPostById,
   DeletePost,
-  AddPostFileLink
+  AddPostFileLink,
+  UpdatePost,
+  RemoveHashtagFromPostLink
 } from "@/src/db/data-access/post/query"
 import { CreateServerAction } from ".."
 import { AuthUserAction } from "../User/AuthUserAction"
@@ -52,6 +54,21 @@ export const CreatePostAction = CreateServerAction(
       } else {
         throw new Error("Unauthorized", { cause: 401 })
       }
+    } catch (error: any) {
+      return {
+        success: false,
+        error: error
+      }
+    }
+  }
+)
+
+export const UpdatePostAction = CreateServerAction(
+  true,
+  async (postId: string, content: string) => {
+    try {
+      const updatedPost = await UpdatePost(postId, content)
+      return { success: true, data: updatedPost }
     } catch (error: any) {
       return {
         success: false,
@@ -161,7 +178,12 @@ export const CreatePollPostAction = CreateServerAction(
 
 export const ToggleLikeAction = CreateServerAction(
   true,
-  async (postId: string, isLiked: boolean, likes: number, space_id?: string) => {
+  async (
+    postId: string,
+    isLiked: boolean,
+    likes: number,
+    space_id?: string
+  ) => {
     try {
       const userId = (await AuthUserAction())?.unique_id
       if (userId) {
@@ -195,7 +217,12 @@ export const ToggleLikeAction = CreateServerAction(
 
 export const CreateCommentAction = CreateServerAction(
   true,
-  async (postId: string, content: string, comments: number, space_id?:string) => {
+  async (
+    postId: string,
+    content: string,
+    comments: number,
+    space_id?: string
+  ) => {
     try {
       const user = await AuthUserAction()
       if (user?.unique_id) {
@@ -333,6 +360,21 @@ export const LinkHashtagsToPostAction = CreateServerAction(
       return {
         success: false,
         error: error.message || "Failed to link hashtags"
+      }
+    }
+  }
+)
+
+export const UnlinkHashtagsFromPostAction = CreateServerAction(
+  true,
+  async (postId: string, hashtagIds: number[]) => {
+    try {
+      await RemoveHashtagFromPostLink(postId, hashtagIds)
+      return { success: true }
+    } catch (error: any) {
+      return {
+        success: false,
+        error: error.message || "Failed to unlink hashtags"
       }
     }
   }


### PR DESCRIPTION
[SW-24](https://spark.etlonline.org/project/08ce22b9-6738-47dd-9acf-b544d832e04d/board?task_id=32fd5eb3-06b3-4e2c-86f5-5efc2f80a420)
**Summary**
This PR adds an Edit option for posts, allowing users to modify their content only if they are the original owner.

**What’s Included**
✔ Add “Edit Post” action in UI for post owner
✔ Implement update logic for post description/caption and hashtags 
✔ Support editing for:
- Text Posts
- Image Posts (caption and hashtags only)
- Poll Posts (caption and hashtags only — poll options remain locked)
✔ UI updates to refresh changed content without full reload

**What’s Not Included**
❌ Editing poll options
❌ Changing attached media (images/files)

**Steps to Test**
- Go to Posts → Add Post
- Create:
- Text Post
- Image Post
- Poll Post
- Publish
- Confirm Edit button appears only for owner
- Modify description → Save → Ensure post updates successfully
- Verify poll options cannot be edited

**Expected Behavior**
- User can edit only their own posts
- Only description/caption and Hashtags changes are allowed

**Result**
This fixes the issue where users were unable to correct mistakes after publishing.