### PR TITLE
SW-64-social-link-crud

### DIFF
--- a/src/components/Dashboard/profile/user/SocialLinksModal.tsx
+++ b/src/components/Dashboard/profile/user/SocialLinksModal.tsx
@@ -169,10 +169,7 @@ export default function EditSocialLinksModal({
               <DialogFooter>
                 <Button
                   loading={submitLoading}
-                  disabled={
-                    submitLoading ||
-                    Object.values(form.watch()).every((value) => !value)
-                  }
+                  disabled={submitLoading}
                   className="w-full"
                 >
                   Save changes

--- a/src/components/ProfileCompletion/StepThree.tsx
+++ b/src/components/ProfileCompletion/StepThree.tsx
@@ -43,9 +43,8 @@ export function StepThree({ step, setStep, user, setUser }: StepThreeProps) {
         github_url: data.github,
         instagram_url: data.instagram,
         twitter_url: data.twitter,
-        personal_website_url: data.personal_website
+        personal_website_url: data.website
       }
-
       const hasAnyLink = Object.values(socialPlatforms).some(
         (val) => val && val.trim() !== ""
       )


### PR DESCRIPTION
[SW-64](https://spark.etlonline.org/project/08ce22b9-6738-47dd-9acf-b544d832e04d/board?task_id=a75d0445-c246-497d-b391-e1f31274d3ff)

**Issue:**

Once a user enters social links during account creation, these links are not visible later in the profile. The user cannot view, update, or delete the social links after saving them, which prevents further modifications.

**Implement:**

After creating account user can view ,edit and delete social links.
