### PR TITLE
SW-36-fixed story points

### DIFF
--- a/src/components/Dashboard/ProjectManagement/BacklogManagement/BacklogItems.tsx
+++ b/src/components/Dashboard/ProjectManagement/BacklogManagement/BacklogItems.tsx
@@ -146,7 +146,6 @@ function BacklogItems({ task }: Props) {
   }
 
   const isParentAvailable = task.parentTask
-
   return (
     <>
       <div
@@ -218,10 +217,27 @@ function BacklogItems({ task }: Props) {
         </div>
 
         <div className="col-span-1 text-center">
-          {task.story_points && task.story_points !== "0"
-            ? task.story_points
-            : "-"}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <div className="truncate max-w-[50px] mx-auto">
+                  {task.story_points && task.story_points !== "0"
+                    ? task.story_points
+                    : "-"}
+                </div>
+              </TooltipTrigger>
+
+              <TooltipContent>
+                <span>
+                  {task.story_points && task.story_points !== "0"
+                    ? task.story_points
+                    : "-"}
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
+
         <div className="col-span-1 text-center">
           {task.assign_to ? (
             <div className="flex justify-center items-center">

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -946,6 +946,7 @@ export default function TaskForm({
                                 min={0}
                                 disabled={!isEditable}
                                 placeholder="Select Points"
+                                max={100}
                                 onBlur={() => setActiveField(null)}
                                 onChange={(e) => {
                                   const val = parseInt(e.target.value, 10)

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -84,7 +84,11 @@ const projectSchema = z.object({
   description: z.string().optional(),
   task_type: z.string().min(1, "Required"),
   task_priority: z.string().min(1, "Required"),
-  story_points: z.string().optional(),
+  story_points: z
+    .number()
+    .max(100, "Story points cannot be more than 100")
+    .transform((value) => value.toString())
+    .optional(),
   status_id: z.string().optional(),
   assign_to: z.string().optional(),
   assign_by: z.string().optional(),
@@ -925,52 +929,48 @@ export default function TaskForm({
                     </div>
 
                     {/* Story Points */}
+                    {/* Story Points */}
                     <div className="space-y-2">
                       <Label>Story Points</Label>
                       <Controller
                         name="story_points"
                         defaultValue=""
                         control={form.control}
-                        render={({ field }) =>
-                          activeField === "points" ? (
-                            <Input
-                              disabled={!isEditable}
-                              id="story_points"
-                              type="number"
-                              min={0}
-                              placeholder="Select Points"
-                              {...field}
-                              className="col-span-3"
-                            />
-                          ) : (
-                            <div
-                              className=" py-2 cursor-pointer flex items-center gap-2"
-                              onClick={() => {
-                                setActiveField("points")
-                                requestAnimationFrame(() => {
-                                  document
-                                    .getElementById("story_points")
-                                    ?.focus()
-                                })
-                              }}
-                            >
-                              <div>
-                                {errors.story_points && (
-                                  <span className="text-red-500 text-sm flex items-center gap-2">
-                                    <CircleAlert size={16} />
-                                    {String(errors.story_points.message)}
-                                  </span>
-                                )}
+                        render={({ field }) => (
+                          <div>
+                            {activeField === "points" ? (
+                              <Input
+                                {...field}
+                                id="story_points"
+                                type="number"
+                                min={0}
+                                disabled={!isEditable}
+                                placeholder="Select Points"
+                                onBlur={() => setActiveField(null)}
+                                onChange={(e) => {
+                                  const val = parseInt(e.target.value, 10)
+                                  field.onChange(isNaN(val) ? "" : val)
+                                }}
+                              />
+                            ) : (
+                              <div
+                                className="py-2 cursor-pointer flex items-center gap-2"
+                                onClick={() => setActiveField("points")}
+                              >
+                                <BarChart2 className="h-5 w-5 text-gray-500" />
+                                <span>{field.value || "Select Points"}</span>
                               </div>
-                              <BarChart2 className="h-5 w-5 text-gray-500" />
-                              <span>{field.value || "Select Points"}</span>
-                            </div>
-                          )
-                        }
+                            )}
+                            {errors.story_points && (
+                              <span className="text-red-500 text-sm flex items-center gap-2 mt-1">
+                                <CircleAlert size={16} />
+                                {String(errors.story_points.message)}
+                              </span>
+                            )}
+                          </div>
+                        )}
                       />
                     </div>
-
-                    {/* Parent Task Selector */}
 
                     {/* Parent Task Selector */}
                     <div className="space-y-2">

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -85,10 +85,13 @@ const projectSchema = z.object({
   task_type: z.string().min(1, "Required"),
   task_priority: z.string().min(1, "Required"),
   story_points: z
-    .number()
-    .max(100, "Story points cannot be more than 100")
-    .transform((value) => value.toString())
-    .optional(),
+    .union([z.number(), z.string()])
+    .refine((value) => {
+      const num = Number(value)
+      return !isNaN(num) && num <= 100
+    }, "Story points cannot be more than 100")
+    .transform((value) => value.toString()),
+
   status_id: z.string().optional(),
   assign_to: z.string().optional(),
   assign_by: z.string().optional(),


### PR DESCRIPTION
[SW-36](https://spark.etlonline.org/project/08ce22b9-6738-47dd-9acf-b544d832e04d/board?task_id=02b1b92a-ad22-478c-84ff-7aa126fcc01f)

** Issue :**

- The system accepts any number of story points without restriction.
- Very large Story Points values overflow their column, extending beyond the container and disrupting the layout.

**Steps to Reproduce:**

1. Open any Community → Channel → Space.
2. Navigate to Project Management → Project → Backlog.
3. Click Add Item.
4. Enter a title, select Issue Type and Priority.
5. Click Assign To and select an assignee.
6. In the Story Points field, enter a very large numeric value.
7. Click Create Task, then close the panel.
8. Observe the task in the backlog list.

**Implement:**

- User can't enter story points more than 100.
- Story Points should be visually truncated or constrained so the UI layout cannot break, even if invalid data is forced in.


