### PR TITLE
Sw 12 long text display

### DIFF
--- a/src/components/Dashboard/posts/ExpandableText.tsx
+++ b/src/components/Dashboard/posts/ExpandableText.tsx
@@ -8,19 +8,27 @@ type Props = {
   className?: string
 }
 
-const ExpandableText: React.FC<Props> = ({ content, lines, className }) => {
+const ExpandableText: React.FC<Props> = ({ content, lines = 6, className }) => {
   const { contentRef, expanded, showToggle, toggle } = useExpandableText(
     lines,
     content
   )
 
+  const clampStyle: React.CSSProperties | undefined = !expanded
+    ? ({
+        display: "-webkit-box",
+        WebkitLineClamp: String(lines) as any,
+        WebkitBoxOrient: "vertical" as any,
+        overflow: "hidden"
+      } as React.CSSProperties)
+    : undefined
+
   return (
     <>
       <p
         ref={contentRef}
-        className={`${className ?? ""} text-justify whitespace-pre-wrap break-words ${
-          expanded ? "" : `line-clamp-${lines}`
-        }`}
+        style={clampStyle}
+        className={`${className ?? ""} text-justify whitespace-pre-wrap break-words`}
       >
         {content}
       </p>

--- a/src/components/Dashboard/posts/post-text.tsx
+++ b/src/components/Dashboard/posts/post-text.tsx
@@ -5,7 +5,6 @@ import PostCommentForm from "./post-comment-form"
 import { SelectPost } from "@/src/db/schema"
 import { Badge } from "../../ui/badge"
 import PostCommentsSection from "./post-comments-section"
-import { usePostNavigation } from "@/src/hooks/usePostNavigation"
 import ExpandableText from "./ExpandableText"
 
 type Props = {
@@ -14,20 +13,11 @@ type Props = {
 }
 
 const TextPost: React.FC<Props> = ({ post, spaceId }) => {
-  const { navigateToPost } = usePostNavigation()
-
   const content = post.content ?? ""
-
-  const handleContentClick = () => {
-    navigateToPost(post.id, spaceId)
-  }
 
   return (
     <>
-      <CardContent
-        className={spaceId !== "shared" ? "cursor-pointer" : ""}
-        onClick={spaceId !== "shared" ? handleContentClick : undefined}
-      >
+      <CardContent>
         <ExpandableText content={content} lines={6} />
 
         <div className="mt-4 flex flex-wrap gap-2">

--- a/src/hooks/useExpandableText.tsx
+++ b/src/hooks/useExpandableText.tsx
@@ -3,15 +3,38 @@ import { useEffect, useRef, useState } from "react"
 export function shouldShowToggle(el: HTMLElement, lines: number = 3): boolean {
   if (!el) return false
 
+  // Temporarily remove any clamp-related inline styles so we can measure
   const previousClamp = el.style.webkitLineClamp
+  const previousOverflow = el.style.overflow
+  const previousDisplay = el.style.display
+  const previousBoxOrient = (el.style as any).webkitBoxOrient
 
   el.style.webkitLineClamp = "unset"
+  el.style.overflow = "visible"
+  el.style.display = "block"
+  ;(el.style as any).webkitBoxOrient = "unset"
 
   const fullHeight = el.scrollHeight
 
+  // Restore previous inline styles
   el.style.webkitLineClamp = previousClamp
+  el.style.overflow = previousOverflow
+  el.style.display = previousDisplay
+  ;(el.style as any).webkitBoxOrient = previousBoxOrient
 
-  const lineHeight = parseFloat(getComputedStyle(el).lineHeight)
+  // Compute line height; if it's not a pixel value (e.g. 'normal'), fall back
+  let lineHeight = parseFloat(getComputedStyle(el).lineHeight)
+  if (Number.isNaN(lineHeight) || lineHeight <= 0) {
+    // Create a temporary inline element to measure a single-line height
+    const span = document.createElement("span")
+    span.style.visibility = "hidden"
+    span.style.whiteSpace = "nowrap"
+    span.textContent = "A"
+    el.appendChild(span)
+    lineHeight = span.getBoundingClientRect().height
+    el.removeChild(span)
+  }
+
   const maxHeight = lineHeight * lines
 
   return fullHeight > maxHeight
@@ -22,10 +45,28 @@ export function useExpandableText(lines: number = 3, content: string = "") {
   const [expanded, setExpanded] = useState(false)
   const [showToggle, setShowToggle] = useState(false)
 
+  // useLayoutEffect so measurements happen before paint and stay consistent
   useEffect(() => {
-    if (contentRef.current) {
-      const shouldShow = shouldShowToggle(contentRef.current, lines)
+    const el = contentRef.current
+    if (!el) return
+
+    const update = () => {
+      const shouldShow = shouldShowToggle(el, lines)
       setShowToggle(shouldShow)
+    }
+
+    update()
+
+    // Recalculate on resize and content size changes (helps when images load)
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+
+    const onResize = () => update()
+    window.addEventListener("resize", onResize)
+
+    return () => {
+      ro.disconnect()
+      window.removeEventListener("resize", onResize)
     }
   }, [content, lines])
 


### PR DESCRIPTION

**issue:**

In the Post & Comment section, long posts or comments are causing readability and layout issues. Extended text is displayed as continuous paragraphs, which stretches the UI and negatively impacts user experience.
**Implement**
1. Long posts and comments should be truncated after a certain limit.
2. Add "Read More" button to  expand content if the user wants to read the full text .
3. Text should be justified for improved readability.
