### PR TITLE
Sw 175 comment visibility

### DIFF
--- a/src/components/Dashboard/ProjectManagement/Task/components/task-comment.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/task-comment.tsx
@@ -322,8 +322,7 @@ export function TaskComment({
                           : ""}
                       </div>
                     </div>
-                    {comment.type === "history" &&
-                    authUser?.unique_id === comment.user_id ? (
+                    {comment.type === "history" ? (
                       <div className="text-sm space-y-3">
                         {Array.isArray(comment.task_history)
                           ? comment.task_history.map((item: any, i: number) => (
@@ -356,7 +355,7 @@ export function TaskComment({
                     )}
                   </div>
                 </div>
-                {comment.type === "comment" ? (
+                {comment.type === "comment" && comment.user_id === userId ? (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" size="sm">


### PR DESCRIPTION
**Issue:**

When a user updates a task, a task history comment is automatically added. However, this comment is not behaving correctly for other users.

**Implement:**

1. Task history comments are visibile to all users.
2. Only the creator of the comment can Edit and Delete.
3. Other users can only read the comments.