### PR TITLE
SW-61-fixed scroll behavior of profile page

### DIFF
--- a/src/components/Dashboard/profile/edit-profile-modal.tsx
+++ b/src/components/Dashboard/profile/edit-profile-modal.tsx
@@ -200,6 +200,7 @@ const EditProfileModal: React.FC = () => {
 
   useEffect(() => {
     if (isOpen) {
+      document.body.style.overflow = "hidden"
       // Reset form fields
       form.reset({
         first_name: user?.first_name || "",
@@ -222,6 +223,12 @@ const EditProfileModal: React.FC = () => {
           value: i.id.toString()
         }))
       )
+    } else {
+      document.body.style.overflow = ""
+    }
+
+    return () => {
+      document.body.style.overflow = ""
     }
   }, [isOpen, user, bio, skills, interests])
 
@@ -251,6 +258,7 @@ const EditProfileModal: React.FC = () => {
         <DialogContent
           className="sm:max-w-[530px]  "
           onInteractOutside={(e) => e.preventDefault()}
+          onWheel={(e) => e.stopPropagation()}
         >
           <DialogHeader>
             <DialogTitle>Edit profile</DialogTitle>

--- a/src/components/Dashboard/profile/edit-profile-modal.tsx
+++ b/src/components/Dashboard/profile/edit-profile-modal.tsx
@@ -200,7 +200,6 @@ const EditProfileModal: React.FC = () => {
 
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = "hidden"
       // Reset form fields
       form.reset({
         first_name: user?.first_name || "",
@@ -223,12 +222,6 @@ const EditProfileModal: React.FC = () => {
           value: i.id.toString()
         }))
       )
-    } else {
-      document.body.style.overflow = ""
-    }
-
-    return () => {
-      document.body.style.overflow = ""
     }
   }, [isOpen, user, bio, skills, interests])
 
@@ -249,7 +242,7 @@ const EditProfileModal: React.FC = () => {
 
   return (
     <>
-      <Dialog open={isOpen} onOpenChange={handleDialogChange} modal={false}>
+      <Dialog open={isOpen} onOpenChange={handleDialogChange}>
         <DialogTrigger asChild>
           <Button variant="edit" size={"sm"} onClick={() => setIsOpen(true)}>
             Edit
@@ -258,7 +251,6 @@ const EditProfileModal: React.FC = () => {
         <DialogContent
           className="sm:max-w-[530px]  "
           onInteractOutside={(e) => e.preventDefault()}
-          onWheel={(e) => e.stopPropagation()}
         >
           <DialogHeader>
             <DialogTitle>Edit profile</DialogTitle>


### PR DESCRIPTION

This PR fixes the scrolling issues in the Skills & Interests dropdown on the profile setup/edit page.

**Implement:**

1. Users can now scroll through the complete list of skills and interests smoothly.
2. Dropdown scrolling no longer affects the rest of the profile page.