### PR TITLE
SW-161 Fix board cutoff and task status dropdown visibility

### DIFF
--- a/src/app/(dashboard)/project/[id]/(project-layout)/backlog/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/backlog/page.tsx
@@ -1,8 +1,13 @@
 import { BacklogManagement } from "@/src/components/Dashboard/ProjectManagement/BacklogManagement/BacklogManagement"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 import React from "react"
 
 function ProjectBackolgs() {
-  return <BacklogManagement />
+  return (
+    <ScrollArea className="min-h-full px-4">
+      <BacklogManagement />
+    </ScrollArea>
+  )
 }
 
 export default ProjectBackolgs

--- a/src/app/(dashboard)/project/[id]/(project-layout)/completed-sprints/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/completed-sprints/page.tsx
@@ -1,8 +1,13 @@
 import CompletedSprints from "@/src/components/Dashboard/ProjectManagement/SprintManagement/CompletedSprints"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 import React from "react"
 
 function page() {
-  return <CompletedSprints />
+  return (
+    <ScrollArea className="min-h-full px-4">
+      <CompletedSprints />
+    </ScrollArea>
+  )
 }
 
 export default page

--- a/src/app/(dashboard)/project/[id]/(project-layout)/files/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/files/page.tsx
@@ -1,8 +1,13 @@
 import { FileSharing } from "@/src/components/Dashboard/ProjectManagement/FileSharing"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 import React from "react"
 
 function ProjectFilesPage() {
-  return <FileSharing />
+  return (
+    <ScrollArea className="min-h-full px-4">
+      <FileSharing />
+    </ScrollArea>
+  )
 }
 
 export default ProjectFilesPage

--- a/src/app/(dashboard)/project/[id]/(project-layout)/layout.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/layout.tsx
@@ -55,9 +55,7 @@ async function layout({ children, params }: Props) {
           </div>
 
           <div className="col-span-10 overflow-hidden">
-            <div className="grid grid-cols-1 h-full">
-              <ScrollArea className="min-h-full px-4">{children}</ScrollArea>
-            </div>
+            <div className="grid grid-cols-1 h-full">{children}</div>
           </div>
         </>
       ) : (

--- a/src/app/(dashboard)/project/[id]/(project-layout)/overview/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/overview/page.tsx
@@ -1,8 +1,13 @@
 import ProjectOverView from "@/src/components/Dashboard/ProjectManagement/ProjectOverView/ProjectOverView"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 import React from "react"
 
 function ProjectOverviewPage() {
-  return <ProjectOverView />
+  return (
+    <ScrollArea className="min-h-full px-4">
+      <ProjectOverView />
+    </ScrollArea>
+  )
 }
 
 export default ProjectOverviewPage

--- a/src/app/(dashboard)/project/[id]/(project-layout)/settings/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/settings/page.tsx
@@ -2,6 +2,7 @@ import { ProjectSettings } from "@/src/components/Dashboard/ProjectManagement/Pr
 import React from "react"
 import { GetProjectByIdAction } from "@/src/server-actions/ProjectManagement/projectManagement"
 import NotFound from "@/src/components/Dashboard/NotFound/NotFound"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 
 interface Props {
   params: Promise<{ id: string }>
@@ -15,7 +16,11 @@ async function page({ params }: Props) {
   if (!currProject.success || !currProject.data) {
     return <NotFound />
   }
-  return <ProjectSettings currProject={currProject.data} />
+  return (
+    <ScrollArea className="min-h-full px-4">
+      <ProjectSettings currProject={currProject.data} />
+    </ScrollArea>
+  )
 }
 
 export default page

--- a/src/app/(dashboard)/project/[id]/(project-layout)/sprint/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/sprint/page.tsx
@@ -1,8 +1,13 @@
 import { SprintManagement } from "@/src/components/Dashboard/ProjectManagement/SprintManagement/SprintManagement"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 import React from "react"
 
 function ProjectSprintspage() {
-  return <SprintManagement />
+  return (
+    <ScrollArea className="h-full px-4">
+      <SprintManagement />
+    </ScrollArea>
+  )
 }
 
 export default ProjectSprintspage

--- a/src/app/(dashboard)/project/[id]/(project-layout)/task/[task_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/task/[task_id]/page.tsx
@@ -1,4 +1,5 @@
 import TaskScreenPage from "@/src/components/Dashboard/ProjectManagement/Task/components/TaskScreen"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 import {
   GetTaskByIdAction,
   GetTaskStatusAction
@@ -21,10 +22,12 @@ async function page({ params }: Props) {
   const currTask = await GetTaskByIdAction(taskId)
 
   return (
-    <TaskScreenPage
-      statuses={projectStatusList.data || []}
-      task={currTask.data}
-    />
+    <ScrollArea className="min-h-full px-4">
+      <TaskScreenPage
+        statuses={projectStatusList.data || []}
+        task={currTask.data}
+      />
+    </ScrollArea>
   )
 }
 

--- a/src/app/(dashboard)/project/[id]/(project-layout)/teams/page.tsx
+++ b/src/app/(dashboard)/project/[id]/(project-layout)/teams/page.tsx
@@ -25,6 +25,7 @@ import { LoaderSizes } from "@/src/components/common/types/loader-types"
 import { useAtomValue } from "jotai"
 import { projectStore } from "@/src/store/project/projectStore"
 import StatusRequiredDialog from "@/src/components/Dashboard/ProjectManagement/StatusRequiredDialog"
+import { ScrollArea } from "@/src/components/ui/scroll-area"
 
 const TeamPage: React.FC = () => {
   const params = useParams<{ id: string }>()
@@ -128,14 +129,16 @@ const TeamPage: React.FC = () => {
   if (!currProject || !currSpace) return <NotFound />
 
   return projectStatusList.length > 0 ? (
-    <div className="p-6">
-      <ProjectTeamList
-        projectId={currProject.id}
-        spaceId={currSpace.id}
-        projectUsers={projectUsers}
-        projectCreatorId={currProject.created_by}
-      />
-    </div>
+    <ScrollArea className="min-h-full px-4">
+      <div className="p-6">
+        <ProjectTeamList
+          projectId={currProject.id}
+          spaceId={currSpace.id}
+          projectUsers={projectUsers}
+          projectCreatorId={currProject.created_by}
+        />
+      </div>
+    </ScrollArea>
   ) : (
     <StatusRequiredDialog openDialog={openDialog} />
   )

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/SprintBoardCard.tsx
@@ -193,7 +193,7 @@ function SprintBoardCard({
   }
 
   return (
-    <>
+    <div className="px-6">
       <Card key={sprint.id} className="mb-6 ">
         <CardHeader className="pb-2">
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
@@ -255,7 +255,7 @@ function SprintBoardCard({
           <SprintStatus />
         </CardFooter>
       </Card>
-    </>
+    </div>
   )
 }
 

--- a/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/TaskForm.tsx
@@ -650,7 +650,7 @@ export default function TaskForm({
                               >
                                 <SelectValue placeholder={"Select status"} />
                               </SelectTrigger>
-                              <SelectContent>
+                              <SelectContent className="max-h-[220px] overflow-auto">
                                 {statuses?.map(
                                   (s) =>
                                     s.id && (


### PR DESCRIPTION
## 🐞 Issue
On a 1920×1080 screen resolution, the **Done** column in the Project Board is partially cut off, making it difficult to view all completed tasks.  
Additionally, the **Done** status is not visible in the Project Task Status dropdown when scrolling.

## 📍 Affected Area
- Spark → Channels → Spaces → Project Management → Project Board
- Project Task Status dropdown

## 🔁 Steps to Reproduce
1. Navigate to **Spark → Channels → Spaces → Project Management → Project Board**
2. Set screen resolution to **1920×1080**
3. Observe the **Done** column on the board
4. Open the **Project Task Status** dropdown and scroll

## ❌ Actual Result
- The **Done** column is partially cut off on the board
- The **Done** status is not visible in the dropdown while scrolling

## ✅ Expected Result
- All board columns, including **Done**, should be fully visible on a **1920×1080** screen
- All task statuses, including **Done**, should be visible and selectable in the dropdown

## 🛠️ Fix Summary
- Adjusted layout handling to ensure the **Done** column remains fully visible on standard screen resolutions
- Fixed dropdown scroll behavior to ensure all task statuses are accessible

## 🧪 Testing
- Verified on **1920×1080** resolution
- Confirmed visibility of the **Done** column and dropdown status
