### PR TITLE
 SW-184: Fix @mention dropdown mouse selection and scroll issue in rich editor

### DIFF
--- a/src/components/Dashboard/Chat/components/MentionList.tsx
+++ b/src/components/Dashboard/Chat/components/MentionList.tsx
@@ -68,7 +68,16 @@ const MentionList = forwardRef<MentionListHandle, any>((props, ref) => {
   }))
 
   return (
-    <div className="bg-popover border rounded-lg shadow-lg p-2 w-80 max-h-64 overflow-y-auto z-50">
+    <div
+      className="bg-popover border rounded-lg shadow-lg p-2 w-80 max-h-64 overflow-y-auto z-50"
+      onMouseDown={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
+      onWheel={(e) => {
+        e.stopPropagation()
+      }}
+    >
       {props.items.length ? (
         props.items.map((item: SelectUser, index: number) => {
           const isCurrentActive = index === activeIndex
@@ -78,11 +87,9 @@ const MentionList = forwardRef<MentionListHandle, any>((props, ref) => {
               key={item.unique_id}
               onMouseEnter={() => setHoverIndex(index)}
               onMouseLeave={() => setHoverIndex(null)}
-              onPointerDown={(e) => {
+              onMouseDown={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
-                setHoverIndex(index)
-                selectItem(index)
               }}
               onClick={() => selectItem(index)}
               className={`w-full text-left px-3 py-2 rounded-md flex items-center gap-2 transition-colors 

--- a/src/components/common/TiptapRichEditor.tsx
+++ b/src/components/common/TiptapRichEditor.tsx
@@ -154,6 +154,12 @@ export default function RichTextEditor({
 
     return text === ""
   }
+  const applyPopupStyles = (popup: any) => {
+    if (popup?.[0]?.popper) {
+      popup[0].popper.style.zIndex = "99999"
+      popup[0].popper.style.pointerEvents = "auto"
+    }
+  }
 
   const extensions = useMemo(() => {
     const baseExtensions: any[] = [
@@ -275,8 +281,8 @@ export default function RichTextEditor({
                     trigger: "manual",
                     placement: "top-start"
                   })
-                  popup[0].popper.style.zIndex = "99999"
-                  popup[0].popper.style.pointerEvents = "auto"
+
+                  applyPopupStyles(popup)
                 },
 
                 onUpdate(props: any) {
@@ -289,6 +295,7 @@ export default function RichTextEditor({
                   popup[0].setProps({
                     getReferenceClientRect: props.clientRect
                   })
+                  applyPopupStyles(popup)
                 },
 
                 onKeyDown(props: any) {


### PR DESCRIPTION
### 🐞 Issue
In the **Project → Task → Comment** section, users can mention project members using `@`.
However:
- Selecting a user from the mention dropdown using **mouse click** did not work after typing a username.
- The mention list **stopped scrolling** when filtering users.
- Keyboard navigation (arrow keys + Enter) worked correctly.

### ✅ Solution
This PR fixes the issues with the `@mention` dropdown behavior:
- Enabled **mouse click selection** even after typing a username.
- Fixed **scrolling issues** in the filtered mention list.
- Ensured consistent behavior between **mouse and keyboard navigation**.

### 🎯 Expected Result
- Users can select members from the `@mention` dropdown using both **mouse** and **keyboard**.
- The mention list remains scrollable and interactive while typing.

### 🔍 Scope
- Project → Task → Comment section
- User mention dropdown (`@`)
