### PR TITLE
SW-50 Fix: Show actor profile picture in project addition notifications

### DIFF
--- a/src/services/notifications/Project/utils.ts
+++ b/src/services/notifications/Project/utils.ts
@@ -16,9 +16,10 @@ export const SendProjectNotifications = async (
       user_id: authUser.unique_id,
       receivers: projectUsers.map((user) => `${user.user_id}`),
       template: {
-        title: `New Project: ${project?.project_name}`,
-        body: `You have been added to project "${project?.project_name}".`,
-        deep_link: createAbsoluteUrl(`/project/${project?.id}/board`)
+        title: `Added to Project: ${project?.project_name}`,
+        body: `${authUser.first_name} ${authUser.last_name} added you to the project "${project?.project_name}".`,
+        deep_link: createAbsoluteUrl(`/project/${project?.id}/board`),
+        icon: authUser.profile_url || undefined
       }
     }
 

--- a/src/services/notifications/Project/utils.ts
+++ b/src/services/notifications/Project/utils.ts
@@ -3,6 +3,7 @@ import { sendPushNotification } from "../PushNotification.utils"
 import { AuthUserAction } from "@/src/server-actions/User/AuthUserAction"
 import { SendSystemNotification } from "../../system-notification/SystemNotification.utils"
 import { createAbsoluteUrl } from "@/src/utils/clientHelper"
+import { getInitials } from "@/src/utils/helpers"
 
 export const SendProjectNotifications = async (
   event_type: string,
@@ -19,7 +20,9 @@ export const SendProjectNotifications = async (
         title: `Added to Project: ${project?.project_name}`,
         body: `${authUser.first_name} ${authUser.last_name} added you to the project "${project?.project_name}".`,
         deep_link: createAbsoluteUrl(`/project/${project?.id}/board`),
-        icon: authUser.profile_url || undefined
+        icon:
+          authUser.profile_url ||
+          getInitials(`${authUser.first_name} ${authUser.last_name}`)
       }
     }
 


### PR DESCRIPTION
## 🐞 Issue Summary

When a user is added to a project, the notification displayed under the header bell icon does not show the profile picture or initials of the user who performed the action.

Unlike other notifications (e.g., chat messages, task assignments), this notification displays a generic **"N" placeholder icon**, causing UI inconsistency and reduced clarity.

---

## 🔁 Steps to Reproduce

1. Log in as **User A**
2. From another account (**User B**), add **User A** to a project
3. Log back in as **User A**
4. Click the header **notification bell icon**
5. Observe the project addition notification

---

## ❌ Actual Result

- The project addition notification displays a generic **"N" placeholder icon**
- The actor who added the user is not visually identifiable

---

## ✅ Expected Result

- The notification displays the **profile picture or initials of the user** who added the member to the project
- Notification UI remains **consistent across all modules** (chat, tasks, projects, etc.)

---

## 🛠️ Fix Overview

- Updated project addition notification payload/UI to include **actor avatar or initials**
- Aligned rendering logic with existing notification types
- Ensured consistent visual behavior across the notification system

---

## 📌 Impact

- Improved UI consistency
- Clearer action attribution in notifications
- Better user experience and readability
