### PR TITLE
SW-166: [Project Board] Display Task Count on Each Board Column

### DIFF
--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/BoardColumn.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/BoardColumn.tsx
@@ -26,12 +26,19 @@ function BoardColumn({ sprint, status, tasks, onTaskClick, setTasks }: Props) {
       : true
   )
 
+  const taskCount = filteredTasks.length
+
   return (
     <div
       ref={setNodeRef}
       className="w-[33%] bg-muted/50 p-2 pb-4 rounded-xl flex-shrink-0 space-y-2"
     >
-      <div className="font-medium text-sm mb-4 text-center">{status?.name}</div>
+      <div className="flex flex-row justify-between mb-4">
+        <div className="font-medium text-sm text-center">{status?.name}</div>
+        <div className="text-xs text-center ">
+          {taskCount} {taskCount === 1 || taskCount === 0 ? "task" : "tasks"}
+        </div>
+      </div>
       {filteredTasks.map((task) => (
         <BoardTaskCard
           task={task}

--- a/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/BoardColumn.tsx
+++ b/src/components/Dashboard/ProjectManagement/SprintManagement/SprintBoard/BoardColumn.tsx
@@ -36,7 +36,7 @@ function BoardColumn({ sprint, status, tasks, onTaskClick, setTasks }: Props) {
       <div className="flex flex-row justify-between mb-4">
         <div className="font-medium text-sm text-center">{status?.name}</div>
         <div className="text-xs text-center ">
-          {taskCount} {taskCount === 1 || taskCount === 0 ? "task" : "tasks"}
+          {taskCount} {taskCount === 1 ? "task" : "tasks"}
         </div>
       </div>
       {filteredTasks.map((task) => (


### PR DESCRIPTION
## 📌 Overview
Currently, the Project Board does not display the total number of tasks in each board column (e.g., To Do, In Progress, Done). Users must manually count tasks, which impacts usability and makes it harder to quickly track progress.

This PR adds a visible task count to each board column, similar to Jira, enabling users to instantly see how many tasks are in each column.

---

## 🐞 Problem
- Task counts are not shown per board column
- Users must manually count tasks
- Reduces efficiency and quick progress tracking

---

## ✅ Solution
- Display the total number of tasks at the top of each board column
- Automatically update the count when tasks are added, moved, or removed
- Improves usability and visibility of task distribution

---

## 🔁 Steps to Reproduce (Before Fix)
1. Navigate to any **Project → Board**
2. Observe board columns (To Do, In Progress, Done)
3. Manually count tasks in each column

---

## 🎯 Expected Result (After Fix)
- Each board column clearly displays the total number of tasks it contains
- Users can quickly track task progress without manual counting

---

## 🧪 Testing
- Verified task counts update correctly when:
  - Adding new tasks
  - Moving tasks between columns
  - Deleting tasks

