### PR TITLE
Sw 170 chat image feature

### DIFF
--- a/src/components/common/LightBox.tsx
+++ b/src/components/common/LightBox.tsx
@@ -95,7 +95,7 @@ export default function ImageLightbox({
                 <Download
                   key="download"
                   onClick={handleDownload}
-                  className="mt-[6%] text-foreground/80 w-6 h-7 hover:text-white cursor-pointer"
+                  className="mt-[6%] text-stone-300 w-6 h-7 hover:text-white cursor-pointer"
                 />
               ]
             : []),


### PR DESCRIPTION
**Issue Title**
Lightbox download icon intermittently not visible in light mode

**Fix**
The download icon is now consistently visible in both light and dark modes.