### PR TITLE
SW-56-fixed mulitple issues file sharing

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
@@ -104,7 +104,10 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
         setDir(removeFileFromPath(dir, selectedFileId))
 
         toast({
-          description: "File deleted successfully!",
+          description:
+            selectedItem && selectedItem.type === "folder"
+              ? "Folder deleted successfully!"
+              : "File deleted successfully!",
           duration: 3000
         })
       } else {
@@ -125,12 +128,15 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
     }
   }
 
-  const selectedFileName =
-    getItemsAtCurrPath().find((item) => item.id === selectedFileId)?.name || ""
+  const selectedItem = getItemsAtCurrPath().find(
+    (item) => item.id === selectedFileId
+  )
+  const selectedFileName = selectedItem?.name || ""
 
   // Check if any items have actions available
   const hasActions = getItemsAtCurrPath().some(
-    (item) => item.type === "file" && canDeleteFile(item)
+    (item) =>
+      (item.type === "file" || item.type === "folder") && canDeleteFile(item)
   )
   const gridCols = hasActions
     ? "grid-cols-[auto_1fr_auto_auto_auto]"
@@ -201,7 +207,9 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
       <div className="divide-y">
         {filteredItems.length === 0 ? (
           <div className="py-8 text-center text-muted-foreground">
-            No matching files or folders
+            {searchQuery
+              ? "No matching files or folders"
+              : "This folder is empty."}
           </div>
         ) : (
           filteredItems.map((item) => (
@@ -256,44 +264,50 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
               </div>
               {hasActions && (
                 <div className="flex items-center justify-center w-16">
-                  {item.type === "file" && canDeleteFile(item) && (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          title="Delete"
-                          variant="ghost"
-                          size="sm"
-                          className="h-8 px-2 text-destructive hover:text-destructive"
-                          onClick={() => setSelectedFileId(item.id)}
-                        >
-                          <Trash className="h-4 w-4 mr-1" />
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Delete File</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Are you sure you want to delete "{selectedFileName}
-                            "? This action cannot be undone.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel
-                            onClick={() => setSelectedFileId(null)}
+                  {(item.type === "file" || item.type === "folder") &&
+                    canDeleteFile(item) && (
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button
+                            title="Delete"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 px-2 text-destructive hover:text-destructive"
+                            onClick={() => setSelectedFileId(item.id)}
                           >
-                            Cancel
-                          </AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={handleDeleteConfirm}
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                            disabled={deleteFileLoading}
-                          >
-                            {deleteFileLoading ? "Deleting..." : "Delete"}
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  )}
+                            <Trash className="h-4 w-4 mr-1" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>
+                              {selectedItem?.type === "folder"
+                                ? "Delete Folder"
+                                : "Delete File"}
+                            </AlertDialogTitle>
+                            <AlertDialogDescription>
+                              {selectedItem?.type === "folder"
+                                ? `Are you sure you want to delete "${selectedFileName}" and all its children? This action cannot be undone.`
+                                : `Are you sure you want to delete "${selectedFileName}"? This action cannot be undone.`}
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel
+                              onClick={() => setSelectedFileId(null)}
+                            >
+                              Cancel
+                            </AlertDialogCancel>
+                            <AlertDialogAction
+                              onClick={handleDeleteConfirm}
+                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                              disabled={deleteFileLoading}
+                            >
+                              {deleteFileLoading ? "Deleting..." : "Delete"}
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
+                    )}
                 </div>
               )}
             </div>

--- a/src/db/data-access/file-sharing/query.ts
+++ b/src/db/data-access/file-sharing/query.ts
@@ -86,17 +86,54 @@ export async function DeleteFile(fileId: number) {
     }
   })
 
-  if (!fileEntry || fileEntry.entity_type !== "file") {
-    throw new Error("File not found")
+  if (
+    !fileEntry ||
+    (fileEntry.entity_type !== "file" && fileEntry.entity_type !== "folder")
+  ) {
+    throw new Error("File or folder not found")
   }
 
-  // Delete from directory table
+  // If it's a folder, recursively delete all children
+  if (fileEntry.entity_type === "folder") {
+    const deleteFolder = async (folderId: number) => {
+      // Get all children
+      const children = await db.query.spaceFileDirectoryTable.findMany({
+        where: eq(spaceFileDirectoryTable.parent_id, folderId),
+        with: {
+          file: true
+        }
+      })
+
+      // Recursively delete each child
+      for (const child of children) {
+        if (child.entity_type === "folder") {
+          await deleteFolder(child.id)
+        } else if (child.entity_type === "file") {
+          // Delete file from files table
+          if (child.entity_id) {
+            await db
+              .delete(filesTable)
+              .where(eq(filesTable.id, child.entity_id))
+          }
+        }
+        // Delete the child directory entry
+        await db
+          .delete(spaceFileDirectoryTable)
+          .where(eq(spaceFileDirectoryTable.id, child.id))
+      }
+    }
+
+    // Delete all children first
+    await deleteFolder(fileId)
+  }
+
+  // Delete the file/folder entry from directory table
   await db
     .delete(spaceFileDirectoryTable)
     .where(eq(spaceFileDirectoryTable.id, fileId))
 
-  // Delete from files table if entity_id exists
-  if (fileEntry.entity_id) {
+  // Delete from files table if entity_id exists (for files)
+  if (fileEntry.entity_id && fileEntry.entity_type === "file") {
     await db.delete(filesTable).where(eq(filesTable.id, fileEntry.entity_id))
   }
 

--- a/src/server-actions/FileSharing/FileSharing.ts
+++ b/src/server-actions/FileSharing/FileSharing.ts
@@ -128,17 +128,20 @@ export const DeleteFileAction = CreateServerAction(
         }
       }
 
-      // Check if user owns the file
+      // Check if user owns the file or folder
       const fileEntry = await db.query.spaceFileDirectoryTable.findFirst({
         where: eq(spaceFileDirectoryTable.id, directoryId),
         with: {
           file: true
         }
       })
-      if (!fileEntry || fileEntry.entity_type !== "file") {
+      if (
+        !fileEntry ||
+        (fileEntry.entity_type !== "file" && fileEntry.entity_type !== "folder")
+      ) {
         return {
           success: false,
-          error: "File not found"
+          error: "File or folder not found"
         }
       }
       const isFileOwner = fileEntry.created_by === user.unique_id
@@ -146,7 +149,7 @@ export const DeleteFileAction = CreateServerAction(
       if (!isFileOwner && !canDeleteSpaceFile) {
         return {
           success: false,
-          error: "You can only delete files that you uploaded"
+          error: "You can only delete files and folders that you created"
         }
       }
 


### PR DESCRIPTION
This PR fixes multiple issues in the file sharing section.

**Issues:**

1. Users were unable to delete folders after creating them.
2. Opening a folder took an unusually long time.
3. Incorrect message displayed for empty folders.

**Fixes:**

1. Users can now delete a folder along with all its children.
2. Opening a folder now takes a reasonable amount of time.
3. Correct message is displayed for empty folders.
4. After deleting a folder, the toast message shows "Folder deleted successfully" instead of "File deleted successfully".