### PR TITLE
bugfix/sw-35: fixed category in all types of space posts

### DIFF
--- a/src/components/Dashboard/posts/post-file.tsx
+++ b/src/components/Dashboard/posts/post-file.tsx
@@ -33,6 +33,11 @@ const FilePost: React.FC<Props> = ({ post, spaceId }) => {
         className={spaceId !== "shared" ? "cursor-pointer" : ""}
         onClick={spaceId !== "shared" ? handleContentClick : undefined}
       >
+        {post.category && (
+          <Badge variant="outline" className="mb-2">
+            {post.category}
+          </Badge>
+        )}
         <p className="text-lg pb-5">{post.content}</p>
         {post?.file ? (
           <Link href={post?.file?.file_path} onClick={handleFileClick}>
@@ -64,7 +69,11 @@ const FilePost: React.FC<Props> = ({ post, spaceId }) => {
         />
         <Separator />
         <PostCommentsSection comments={post.postComments || []} />
-        <PostCommentForm postId={post.id} comments={post.comments} spaceId={spaceId}/>
+        <PostCommentForm
+          postId={post.id}
+          comments={post.comments}
+          spaceId={spaceId}
+        />
       </CardFooter>
     </>
   )

--- a/src/components/Dashboard/posts/post-image.tsx
+++ b/src/components/Dashboard/posts/post-image.tsx
@@ -34,6 +34,12 @@ const ImagePost: React.FC<Props> = ({ post, spaceId }) => {
     <>
       <CardContent>
         <p className="text-lg pb-5">{post.content}</p>
+
+        {post.category && (
+          <Badge variant="outline" className="mb-2">
+            {post.category}
+          </Badge>
+        )}
         {/* Images */}
         {images.length > 0 && (
           <div

--- a/src/components/Dashboard/posts/post-poll.tsx
+++ b/src/components/Dashboard/posts/post-poll.tsx
@@ -117,9 +117,14 @@ const PollPost: React.FC<Props> = ({ post, spaceId }) => {
   return (
     <>
       <CardContent
-        className={spaceId !== "shared" ? "cursor-pointer" : ""}
-        onClick={spaceId !== "shared" ? handleContentClick : undefined}
+        className={spaceId !== undefined ? "cursor-pointer" : ""}
+        onClick={spaceId !== undefined ? handleContentClick : undefined}
       >
+        {post.category && (
+          <Badge variant="outline" className="mb-2">
+            {post.category}
+          </Badge>
+        )}
         <p className="font-semibold mb-4">{post.content}</p>
         {post.files && post.files.length > 0 && (
           <div

--- a/src/components/Dashboard/posts/updatePostModal.tsx
+++ b/src/components/Dashboard/posts/updatePostModal.tsx
@@ -281,9 +281,11 @@ function UpdatePostModal({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edit Post</DialogTitle>
-          <DialogDescription>
-            Here you can edit your post details.
-          </DialogDescription>
+          {isPoll && canEditPoll && (
+            <DialogDescription>
+              Here you can edit your post details.
+            </DialogDescription>
+          )}
         </DialogHeader>
         <form
           onSubmit={form.handleSubmit(handleUpdatePost)}


### PR DESCRIPTION
**Issues:**

1. Space post category was available only for text posts and hidden for image, file, and poll posts.
2. Edit Post modal title was shown incorrectly after voting started.

**Fixed:**

1. Space post category is now available for all post types (text, image, file, and poll).
2. Edit Post modal title now shows only for poll posts before voting starts