### PR TITLE
 bugfix/sw-56-implement delete icon show for creator

### DIFF
--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirNav.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirNav.tsx
@@ -46,13 +46,13 @@ const DirNav: React.FC<DirNavProps> = ({ navigateToFolder }) => {
         )
       })
 
-  const navigateUp = () => {
+  const navigateUp = async () => {
     if (currentPath === "/") return
 
     const pathParts = currentPath.split("/")
     pathParts.pop()
     const parentPath = pathParts.join("/") || "/"
-    setCurrentPath(parentPath)
+    await navigateToFolder(parentPath)
   }
 
   return (

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/DirView.tsx
@@ -158,28 +158,28 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
 
     if (foldersToFetch.length === 0) return
 
-    const fetchAllFolderContents = async () => {
+    // Lazy load folder sizes in background without blocking
+    const timer = setTimeout(async () => {
       try {
-        const results = await Promise.all(
-          foldersToFetch.map((folder) => getDirContent(folder.id))
-        )
-
-        const newSizes: Record<number, number> = {}
-
-        results.forEach((res, index) => {
-          const folderId = foldersToFetch[index].id
-
-          const totalSize = (res?.data || [])
-            .filter((item: any) => item.entity_type === "file")
-            .reduce(
-              (sum: number, item: any) => sum + (item.file?.file_size ?? 0),
-              0
-            )
-
-          newSizes[folderId] = totalSize
-        })
-
-        setFolderSizes((prev) => ({ ...prev, ...newSizes }))
+        // Fetch sequentially to avoid overwhelming the server
+        for (const folder of foldersToFetch) {
+          try {
+            const res = await getDirContent(folder.id)
+            const totalSize = (res?.data || [])
+              .filter((item: any) => item.entity_type === "file")
+              .reduce(
+                (sum: number, item: any) => sum + (item.file?.file_size ?? 0),
+                0
+              )
+            setFolderSizes((prev) => ({ ...prev, [folder.id]: totalSize }))
+          } catch (error) {
+            toast({
+              variant: "destructive",
+              description: `Failed to fetch size for folder "${folder.name}"`,
+              duration: 3000
+            })
+          }
+        }
       } catch (error) {
         toast({
           variant: "destructive",
@@ -187,10 +187,10 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
           duration: 3000
         })
       }
-    }
+    }, 100)
 
-    fetchAllFolderContents()
-  }, [folderItems, folderSizes, getDirContent])
+    return () => clearTimeout(timer)
+  }, [folderItems, getDirContent, toast])
 
   return (
     <div className="p-4">
@@ -264,7 +264,9 @@ const DirView: React.FC<DirViewProps> = ({ navigateToFolder, searchQuery }) => {
               </div>
               {hasActions && (
                 <div className="flex items-center justify-center w-16">
-                  {(item.type === "file" || item.type === "folder") &&
+                  {(item.type === "file" ||
+                    item.type === "folder" ||
+                    authUser?.unique_id === item.created_by) &&
                     canDeleteFile(item) && (
                       <AlertDialog>
                         <AlertDialogTrigger asChild>

--- a/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
+++ b/src/components/Dashboard/Channels/ChannelDetails/Spaces/FileDir.tsx
@@ -29,8 +29,9 @@ import {
 import { useParams } from "next/navigation"
 import { DirItem } from "./types/spaces-types"
 import { formatFileSize, slugify } from "@/src/utils/helpers"
-import { useAtom } from "jotai"
+import { useAtom, useAtomValue } from "jotai"
 import { spaceStore } from "@/src/store/space/spaceStore"
+import { userStore } from "@/src/store/user/userStore"
 import { SelectSpaceFileDirectory } from "@/src/db/schema"
 import { useToast } from "@/src/hooks/use-toast"
 import DirView from "./DirView"
@@ -62,6 +63,7 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
   const [dir, setDir] = useAtom(spaceStore.dir)
   const [currentPath, setCurrentPath] = useAtom(spaceStore.currDirPath)
   const [currSpace, setCurrSpace] = useAtom(spaceStore.selectedSpace)
+  const authUser = useAtomValue(userStore.AuthUser)
 
   const [fileData, setFileData] = useState<FileData | null>(null)
 
@@ -215,7 +217,8 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
           currentPath === "/"
             ? `/${newFolderName.current}`
             : `${currentPath}/${newFolderName.current}`,
-        children: []
+        children: [],
+        created_by: authUser?.unique_id
       }
 
       if (currentPath === "/") {
@@ -241,6 +244,9 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
 
   const navigateToFolder = async (path: string) => {
     const selectedFolder = findItemByPath(dir, path)
+
+    // Set path immediately for instant navigation
+    setCurrentPath(path)
 
     if (selectedFolder && selectedFolder.type === "folder") {
       try {
@@ -287,11 +293,13 @@ const FileDir: React.FC<FileDirProps> = ({ addItemToPath, findItemByPath }) => {
           })
         }
       } catch (error) {
-        console.error("Error fetching folder contents:", error)
+        toast({
+          variant: "destructive",
+          description: "Failed to load folder contents",
+          duration: 3000
+        })
       }
     }
-
-    setCurrentPath(path)
   }
 
   const processFileForUpload = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/db/data-access/file-sharing/query.ts
+++ b/src/db/data-access/file-sharing/query.ts
@@ -6,7 +6,8 @@ import { space } from "postcss/lib/list"
 export async function CreateFolder(
   id: string | number,
   folderName: string,
-  folderSlug: string
+  folderSlug: string,
+  createdBy?: string
 ) {
   return await db
     .insert(spaceFileDirectoryTable)
@@ -15,7 +16,8 @@ export async function CreateFolder(
       parent_id: typeof id === "number" ? id : undefined,
       entity_name: folderName,
       entity_type: "folder",
-      entity_slug: folderSlug
+      entity_slug: folderSlug,
+      created_by: createdBy
     })
     .returning()
 }

--- a/src/server-actions/FileSharing/FileSharing.ts
+++ b/src/server-actions/FileSharing/FileSharing.ts
@@ -22,7 +22,19 @@ export const CreateNewFolderAction = CreateServerAction(
   true,
   async (id: string | number, folderName: string, folderSlug: string) => {
     try {
-      const result = await CreateFolder(id, folderName, folderSlug)
+      const user = await AuthUserAction()
+      if (!user) {
+        return {
+          success: false,
+          error: "Unauthorized"
+        }
+      }
+      const result = await CreateFolder(
+        id,
+        folderName,
+        folderSlug,
+        user.unique_id
+      )
       return { success: true, data: result[0] }
     } catch (error) {
       console.error("Error creating folder:", error)


### PR DESCRIPTION
**Issue:**

1. Clicking on a folder took an unusually long time to open, even when the folder was empty.
2. After creating a folder, the delete icon was not visible for the folder creator.

**Fixes**

1. Optimized folder navigation to ensure folders open instantly, including empty folders.
2. The delete icon is now correctly displayed for the folder creator immediately after folder creation.