### PR TITLE
Bugfix/sw 143 result no found

### DIFF
--- a/src/components/Dashboard/CommandCenter/CommandCenter.tsx
+++ b/src/components/Dashboard/CommandCenter/CommandCenter.tsx
@@ -92,12 +92,13 @@ export default function CommandCenter() {
         />
 
         <CommandList>
-          {loading && (
+          {loading ? (
             <div className="w-full flex justify-center p-2">
               <Loader />
             </div>
+          ) : (
+            <CommandEmpty>No results found.</CommandEmpty>
           )}
-          <CommandEmpty>No results found.</CommandEmpty>
 
           <CommandGroup heading="Users">
             {peopleList.map((person) => (


### PR DESCRIPTION
The Issue: The search bar prematurely displayed a "No result found" message during the data-fetching phase, causing confusion before results had a chance to load.

The Fix: Updated the UI logic to show only a loading indicator while fetching data, ensuring the "No result found" message only appears after the search process completes with zero matches.