### PR TITLE
Bugfix/SW-195: Fix application error when saving content in Rich Text Editor

### DIFF
--- a/src/components/common/Shortcut/hooks/useShortcut.tsx
+++ b/src/components/common/Shortcut/hooks/useShortcut.tsx
@@ -186,7 +186,11 @@ const useShortcut = () => {
         slugToUse = s.community.slug
       } else if (shortcut.type === "channel" && s.channel?.channel_slug) {
         slugToUse = s.channel.channel_slug
-      } else if (shortcut.type === "space" && s.space?.space_slug) {
+      } else if (
+        shortcut.type === "space" &&
+        s.space?.space_slug &&
+        s.space.channel?.channel_slug
+      ) {
         slugToUse = `${s.space.channel.channel_slug}/spaces/${s.space.space_slug}`
         console.log(s.space, "slugToUse")
       } else if (shortcut.type === "project" && s.project?.project_slug) {


### PR DESCRIPTION
## Summary

This PR fixes an issue in the **Space → Overview** Rich Text Editor where saving updated content or adding/editing links redirects users to an Application Error page instead of persisting changes.

The error occurred repeatedly, making the editor unreliable and preventing users from managing Space Overview content.

---

## Problem

### Actual Result
- Clicking **Save** redirects the user to an Application Error page
- Updated content or link changes are **not saved**
- Issue occurs multiple times during editing

### Expected Result
- Content and links save successfully
- User remains on the **Space Overview** page after saving
- No application error is triggered

---

## Impact
- Users are unable to update Space Overview content
- High impact on content management workflows
- Degraded user experience due to repeated failures

---

## Fix
- Resolved the application error triggered on save
- Ensured editor content and links persist correctly
- Stabilized the save flow to prevent redirection to the error page

---

## Testing
- Verified content updates save successfully
- Verified adding and editing links works as expected
- Confirmed no Application Error occurs on Save
