### PR TITLE
sw-87-limit-qualification-certification-length

### DIFF
--- a/src/components/Dashboard/profile/CertificateModal.tsx
+++ b/src/components/Dashboard/profile/CertificateModal.tsx
@@ -45,11 +45,28 @@ interface Props {
 }
 
 const userCertificateSchema = z.object({
-  title: z.string().min(1, "Required"),
-  institute: z.string().min(1, "Required"),
-  year: z.string().refine((val) => moment(val, "YYYY", true).isValid(), {
-    message: "Invalid year"
-  })
+  title: z
+    .string()
+    .min(1, "Certificate name is required")
+    .max(100, "Certificate name cannot exceed 100 characters"),
+
+  institute: z
+    .string()
+    .min(1, "Institute name is required")
+    .max(100, "Institute name cannot exceed 100 characters"),
+
+  year: z
+    .string()
+    .min(1, "Year is required")
+    .refine((val) => moment(val, "YYYY", true).isValid(), {
+      message: "Invalid year format"
+    })
+    .refine((val) => moment(val, "YYYY", true).year() >= 1990, {
+      message: "Year must be 1990 or later"
+    })
+    .refine((val) => moment(val, "YYYY", true).year() <= moment().year(), {
+      message: "Year cannot be in the future"
+    })
 })
 
 const CertificateModal = ({
@@ -197,6 +214,15 @@ const CertificateModal = ({
       isDirty: isChanged,
       onClose: () => setIsDialogOpen(false)
     })
+  const title = form.watch("title")
+  const institute = form.watch("institute")
+  const year = form.watch("year")
+
+  useEffect(() => {
+    if (title || institute || year) {
+      form.trigger(["title", "institute", "year"])
+    }
+  }, [title, institute, year, isDialogOpen])
 
   return (
     <>


### PR DESCRIPTION
**Issue:**
The Certificate Name and Institute Name input fields allowed users to enter excessively long text or full paragraphs. There was no proper character limit in place, which cause the UI layout to break.

**Fix:**
A character limit of 100 characters has been applied to both the Certificate Name and Institute Name fields.
With this limitation in place, additional truncation or ellipsis handling is no longer required.