### PR TITLE
Bugfix/sw 83 shortcut sidebar issue

### DIFF
--- a/src/components/Dashboard/Sidebar.tsx/nav-main.tsx
+++ b/src/components/Dashboard/Sidebar.tsx/nav-main.tsx
@@ -138,7 +138,9 @@ export default function NavMain({
                         <CollapsibleContent>
                           <SidebarMenuSub>
                             {item.items.map((subItem) => (
-                              <TooltipProvider key={subItem.title}>
+                              <TooltipProvider
+                                key={subItem.url + subItem.title}
+                              >
                                 <Tooltip delayDuration={300}>
                                   <SidebarMenuSubItem>
                                     <TooltipTrigger asChild>

--- a/src/components/Dashboard/Sidebar.tsx/nav-main.tsx
+++ b/src/components/Dashboard/Sidebar.tsx/nav-main.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ChevronRight, Lock, Type as type, type LucideIcon } from "lucide-react"
+import { ChevronRight, Lock } from "lucide-react"
 import {
   Collapsible,
   CollapsibleContent,
@@ -26,6 +26,8 @@ import {
 import Link from "next/link"
 import { NavItem } from "./nav-types"
 import { usePathname } from "next/navigation"
+import { useSidebar } from "@/src/components/ui/sidebar"
+import { Button } from "@/src/components/ui/button"
 
 export default function NavMain({
   label,
@@ -35,6 +37,7 @@ export default function NavMain({
   items: NavItem[]
 }) {
   const pathName = usePathname()
+  const sidebar = useSidebar()
   return (
     <SidebarGroup>
       <SidebarGroupLabel>{label || ""}</SidebarGroupLabel>
@@ -50,23 +53,60 @@ export default function NavMain({
                   defaultOpen={item.isActive}
                 >
                   <SidebarMenuItem>
-                    <SidebarMenuButton
-                      className={
-                        isActive
-                          ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                          : ""
-                      }
-                      asChild
-                      tooltip={item.title}
-                    >
-                      <Link href={item.url}>
-                        {item.icon ? <item.icon /> : null}
-                        <span>{item.title}</span>
-                        {item?.isPrivate ? (
-                          <Lock className="text-sm" height={10} />
-                        ) : null}
-                      </Link>
-                    </SidebarMenuButton>
+                    {item.items && item.items.length ? (
+                      // If item has children, make the whole button a collapsible trigger
+                      <CollapsibleTrigger asChild>
+                        <SidebarMenuButton
+                          className={
+                            isActive
+                              ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                              : ""
+                          }
+                          asChild
+                          tooltip={item.title}
+                        >
+                          <Button
+                            variant="ghost"
+                            className="w-full justify-start text-left"
+                            onClick={() => {
+                              // Expand app sidebar first if collapsed, then let CollapsibleTrigger toggle
+                              if (sidebar?.state === "collapsed")
+                                sidebar.toggleSidebar()
+                            }}
+                          >
+                            {item.icon ? <item.icon /> : null}
+                            <span>{item.title}</span>
+                            {item?.isPrivate ? (
+                              <Lock className="text-sm" height={10} />
+                            ) : null}
+                          </Button>
+                        </SidebarMenuButton>
+                      </CollapsibleTrigger>
+                    ) : (
+                      <SidebarMenuButton
+                        className={
+                          isActive
+                            ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                            : ""
+                        }
+                        asChild
+                        tooltip={item.title}
+                      >
+                        <Link
+                          href={item.url}
+                          onClick={() => {
+                            if (sidebar?.state === "collapsed")
+                              sidebar.toggleSidebar()
+                          }}
+                        >
+                          {item.icon ? <item.icon /> : null}
+                          <span>{item.title}</span>
+                          {item?.isPrivate ? (
+                            <Lock className="text-sm" height={10} />
+                          ) : null}
+                        </Link>
+                      </SidebarMenuButton>
+                    )}
                     {item.items?.length ? (
                       <>
                         <CollapsibleTrigger asChild>
@@ -77,13 +117,19 @@ export default function NavMain({
                         </CollapsibleTrigger>
                         <CollapsibleContent>
                           <SidebarMenuSub>
-                            {item.items?.map((subItem) => (
+                            {item.items.map((subItem) => (
                               <TooltipProvider key={subItem.title}>
                                 <Tooltip delayDuration={300}>
                                   <SidebarMenuSubItem>
                                     <TooltipTrigger asChild>
                                       <SidebarMenuSubButton asChild>
-                                        <Link href={subItem.url}>
+                                        <Link
+                                          href={subItem.url}
+                                          onClick={() => {
+                                            if (sidebar?.state === "collapsed")
+                                              sidebar.toggleSidebar()
+                                          }}
+                                        >
                                           {subItem.icon ? (
                                             <subItem.icon />
                                           ) : null}

--- a/src/components/Dashboard/Sidebar.tsx/nav-main.tsx
+++ b/src/components/Dashboard/Sidebar.tsx/nav-main.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ChevronRight, Lock } from "lucide-react"
+import { useEffect, useState } from "react"
 import {
   Collapsible,
   CollapsibleContent,
@@ -38,6 +39,14 @@ export default function NavMain({
 }) {
   const pathName = usePathname()
   const sidebar = useSidebar()
+  const [openItems, setOpenItems] = useState<Set<string>>(new Set())
+
+  // Close all dropdowns when sidebar is collapsed
+  useEffect(() => {
+    if (sidebar?.state === "collapsed") {
+      setOpenItems(new Set())
+    }
+  }, [sidebar?.state])
   return (
     <SidebarGroup>
       <SidebarGroupLabel>{label || ""}</SidebarGroupLabel>
@@ -45,12 +54,23 @@ export default function NavMain({
         {items && items.length
           ? items.map((item) => {
               const isActive = pathName.includes(item.url)
+              const itemKey = item.url + item.title
+              const isOpen = openItems.has(itemKey)
 
               return (
                 <Collapsible
-                  key={item.url + item.title}
+                  key={itemKey}
                   asChild
-                  defaultOpen={item.isActive}
+                  open={isOpen}
+                  onOpenChange={(open) => {
+                    const newOpenItems = new Set(openItems)
+                    if (open) {
+                      newOpenItems.add(itemKey)
+                    } else {
+                      newOpenItems.delete(itemKey)
+                    }
+                    setOpenItems(newOpenItems)
+                  }}
                 >
                   <SidebarMenuItem>
                     {item.items && item.items.length ? (


### PR DESCRIPTION

**PR Title**
Fix: Sidebar shortcut click not triggering results.

**Issue**

1. In collapsed sidebar, clicking shortcut letters (e.g., C for Community, S for Space) did not display results.
2. In expanded sidebar, clicking category name (Community / Space) did not trigger results.
3. Only dropdown arrow click was working.

**Fixed**

1. Added click handler to shortcut icons in collapsed sidebar.
2. On shortcut click, sidebar now expands and shows dropdown menu items of the corresponding category.
3. Made category names clickable in expanded sidebar to show dropdown menu and now both dropdown icon and category    name are clickable and display the menu correctly.
4. Platform navigation items (Profile, Chat, Connections, Communities, Channels):
5. Navigate to corresponding pages from collapsed sidebar.
6. Automatically expand sidebar after navigation for consistent UX.
7. Unified behavior between Platform navigation and Shortcuts interactions.