### PR TITLE
Fix/SW-191 add padding to dropdown arrow and disable navigation arrows for single image preview

### DIFF
--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -668,7 +668,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
     // Extract all image URLs from messages, maintaining order
     const allImages: string[] = []
     messages.forEach((msg) => {
-      if (msg.type === "image") {
+      if (msg.type === "image" && msg.is_deleted !== 1) {
         const parts = msg.message?.split(",") || []
         if (parts.length >= 1) {
           const imagePath = parts[0]

--- a/src/components/Dashboard/Chat/index.tsx
+++ b/src/components/Dashboard/Chat/index.tsx
@@ -948,7 +948,7 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
                                 <div className="relative group flex flex-col">
                                   {/* MESSAGE BUBBLE */}
                                   <div
-                                    className={`rounded-lg py-2 pl-2 rich-editor  flex gap-1 flex-col pr-6 ${
+                                    className={`rounded-lg py-2 px-2 group-hover:pr-6 rich-editor  flex gap-1 flex-col  ${
                                       message.sender_id === authUser?.unique_id
                                         ? "bg-primary text-primary-foreground"
                                         : "bg-muted"
@@ -1065,16 +1065,13 @@ export function ChatScreen({ currentChatSSR, allChatsSSR }: ChatScreenProps) {
                                   {!message.is_deleted &&
                                     message.sender_id ===
                                       authUser?.unique_id && (
-                                      <div className="absolute self-end">
+                                      <div className="absolute top-2 right-2">
                                         <DropdownMenu>
-                                          <DropdownMenuTrigger asChild>
-                                            <Button
-                                              variant="ghost"
-                                              size="icon"
-                                              className="opacity-0 group-hover:opacity-100 hover:bg-transparent transform -translate-y-2 group-hover:translate-y-0 transition-all duration-200"
-                                            >
-                                              <ChevronDown className="w-4 h-4 text-black" />
-                                            </Button>
+                                          <DropdownMenuTrigger
+                                            asChild
+                                            className="opacity-0 group-hover:opacity-100 hover:bg-transparent transform -translate-y-2 group-hover:translate-y-0 transition-all duration-200"
+                                          >
+                                            <ChevronDown className="w-4 h-4 text-black" />
                                           </DropdownMenuTrigger>
 
                                           <DropdownMenuContent

--- a/src/components/common/LightBox.tsx
+++ b/src/components/common/LightBox.tsx
@@ -83,6 +83,18 @@ export default function ImageLightbox({
       styles={{
         container: { zIndex: 9999, pointerEvents: "auto" }
       }}
+      carousel={{
+        finite: slides.length <= 1
+      }}
+      controller={{
+        disableSwipeNavigation: slides.length > 1
+      }}
+      zoom={{
+        maxZoomPixelRatio: 3,
+        zoomInMultiplier: 2,
+        doubleTapDelay: 300,
+        doubleClickDelay: 300
+      }}
       on={{
         view: ({ index }) => {
           currentIndexRef.current = index


### PR DESCRIPTION
## 🐞 Summary

This PR fixes two UI/UX issues related to chat image handling that impact visual alignment and usability.

---

## 🎯 Issues Addressed

### 1. Dropdown Arrow Padding on Chat Images

**Problem:**
- The dropdown arrow icon displayed on the top-right corner of chat images is positioned too close to the image edge.
- Lack of padding makes the icon appear cramped and harder to interact with.

**Fix:**
- Added proper padding around the dropdown arrow.
- Ensured consistent spacing from image boundaries.
- Improved visual balance and touch target accessibility.

---

### 2. Navigation Arrows Enabled for Single Image Preview

**Problem:**
- When opening the image preview for a single image, left and right navigation arrows remain active.
- This creates confusion since navigation is not applicable.

**Fix:**
- Detect when only one image is present in the preview.
- Disable or hide navigation arrows in single-image mode.
- Prevent unnecessary interactions and improve UX clarity.

---

## ✅ Expected Behavior

- Dropdown arrow appears properly spaced and aligned.
- Image preview shows navigation controls only when multiple images exist.
- Single-image preview displays no active navigation arrows.
