### PR TITLE
fix/SW-202: task image preview and chat input placeholder

### DIFF
--- a/src/components/common/Tiptap/RichEditorFormat.css
+++ b/src/components/common/Tiptap/RichEditorFormat.css
@@ -125,3 +125,12 @@
   border-left: 2px solid #666a72;
   padding: 4px 3px;
 }
+
+/* TipTap Placeholder */
+.ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  color: #9ca3af;
+  pointer-events: none;
+  float: left;
+  height: 0;
+}

--- a/src/components/common/Tiptap/TiptapRichEditor.tsx
+++ b/src/components/common/Tiptap/TiptapRichEditor.tsx
@@ -225,7 +225,6 @@ export default function RichTextEditor({
       popup[0].popper.style.pointerEvents = "auto"
     }
   }
-
   const schemaExtensions = useMemo(
     () =>
       createSchemaExtensions({
@@ -240,39 +239,7 @@ export default function RichTextEditor({
     const editorOnlyExtensions: any[] = []
 
     // Custom Image NodeView (UI only)
-    editorOnlyExtensions.push(
-      Image.extend({
-        addNodeView() {
-          return ({ node, getPos, editor }) => {
-            const dom = document.createElement("div")
-            dom.className = "tiptap-image-wrapper relative inline-block"
-
-            const img = document.createElement("img")
-            img.src = node.attrs.src
-            img.className = "rounded-md max-w-full h-auto"
-
-            dom.appendChild(img)
-
-            const deleteBtn = document.createElement("button")
-            deleteBtn.textContent = "✕"
-            deleteBtn.onclick = (e) => {
-              e.stopPropagation()
-              editor
-                .chain()
-                .focus()
-                .deleteRange({
-                  from: getPos(),
-                  to: getPos() + node.nodeSize
-                })
-                .run()
-            }
-
-            dom.appendChild(deleteBtn)
-            return { dom }
-          }
-        }
-      })
-    )
+    editorOnlyExtensions.push(CustomImage)
 
     // Mention UI logic
     if (showMentions && mentionUsers.length > 0) {
@@ -396,7 +363,7 @@ export default function RichTextEditor({
 
   const editor = useEditor({
     extensions,
-    content: value,
+    content: value || "",
     editable,
     editorProps: {
       attributes: {

--- a/src/components/common/Tiptap/tiptapSchemaExtensions.ts
+++ b/src/components/common/Tiptap/tiptapSchemaExtensions.ts
@@ -19,6 +19,7 @@ export const createSchemaExtensions = (
   options: SchemaExtensionOptions = {}
 ) => {
   const { limit = 1000, placeholder = "", clickableLinks = false } = options
+  console.log("Creating schema extensions with options:", options)
 
   const extensions: any[] = [
     StarterKit.configure({
@@ -26,7 +27,10 @@ export const createSchemaExtensions = (
     }),
 
     Placeholder.configure({
-      placeholder
+      placeholder: placeholder || "Write something...",
+      // emptyEditorClass: "is-editor-empty",
+      showOnlyWhenEditable: true,
+      showOnlyCurrent: false
     }),
 
     Underline,


### PR DESCRIPTION
## Description

This PR fixes two UI issues affecting Project Management tasks and Chat functionality:

1️⃣ **Task Description – Image Preview Not Working**  
- **Module:** Project Management → Task  
- **Issue:** Images added in the task description using the rich text editor do not open in preview/full view.  
- **Fix:** Restores image preview functionality so clicking an image opens it in expanded view.  

2️⃣ **Chat – Input Field Placeholder Text Missing**  
- **Module:** Main Chat & Space Chat  
- **Issue:** Placeholder text in the message input field is not visible before typing.  
- **Fix:** Restores placeholder text (e.g., “Type a message…”) in the chat input field.  

## Steps to Reproduce

### Task Image Preview Issue
1. Navigate to **Project Management**.  
2. Open any task.  
3. Add an image in the **Task Description** using the rich text editor.  
4. Click on the image.  

**Actual Result:** Image preview does not open.  
**Expected Result:** Clicking the image opens it in preview/full view mode.  

### Chat Placeholder Issue
1. Open **Main Chat** or any **Space Chat**.  
2. Observe the message input field before typing.  

**Actual Result:** Placeholder text is not visible.  
**Expected Result:** Placeholder text (e.g., “Type a message…”) should be displayed.  



