### PR TITLE
sw-215-fixed comment order display

### DIFF
--- a/src/components/Dashboard/ProjectManagement/Task/components/task-comment.tsx
+++ b/src/components/Dashboard/ProjectManagement/Task/components/task-comment.tsx
@@ -129,7 +129,7 @@ export function TaskComment({
 
       setComments((prev) => {
         if (prev.some((c) => c.id === newCommentWithUser.id)) return prev
-        return [...prev, newCommentWithUser]
+        return [newCommentWithUser, ...prev]
       })
 
       setTotalCount((prev) => prev + 1)


### PR DESCRIPTION

**Issue**
When a new comment is added, it appears at the bottom of the comments list instead of the top.

**Fix**
Updated the comment state logic to prepend the new comment to the comments array rather than appending it.

**Result**
Newly added comments now appear at the top of the list (most recent first), improving user experience and aligning with standard comment behavior.