### PR TITLE
Bug/sw 34 poll vote display incorrect

### DIFF
--- a/src/components/Dashboard/posts/post-poll.tsx
+++ b/src/components/Dashboard/posts/post-poll.tsx
@@ -230,7 +230,8 @@ const PollPost: React.FC<Props> = ({ post, spaceId }) => {
                   {option.option_text}
                   {option.vote_count > 0 && (
                     <span className="ml-2 text-sm text-gray-500">
-                      ({option.vote_count} votes)
+                      ({option.vote_count}{" "}
+                      {option.vote_count === 1 ? "vote" : "votes"})
                     </span>
                   )}
                 </Label>


### PR DESCRIPTION
**Title:** 
Fix poll vote count pluralization in Posts

**Description:** 

Updated the poll vote count label to display correct singular and plural text dynamically based on the current number of votes (for example, “1 vote” and “2 votes”). 