### PR TITLE
SW-193 : UI button fix and like toggele and name truncate fix

### DIFF
--- a/src/components/Dashboard/PlatformSuggestionCard/PlatformSuggestionCard.tsx
+++ b/src/components/Dashboard/PlatformSuggestionCard/PlatformSuggestionCard.tsx
@@ -67,7 +67,7 @@ export function PlatformSuggestionCard({ authUser }: Props) {
             suggestedUsers.map((suggestion) => (
               <div
                 key={suggestion.unique_id}
-                className="flex items-center justify-between gap-1 "
+                className="flex items-center justify-between gap-2"
               >
                 <div className="flex items-center space-x-3 flex-1 min-w-0">
                   <Avatar>
@@ -80,18 +80,21 @@ export function PlatformSuggestionCard({ authUser }: Props) {
                     </AvatarFallback>
                   </Avatar>
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium truncate line-clamp-2">
+                    <p className="text-sm font-medium truncate">
                       {suggestion.first_name} {suggestion.last_name}
                     </p>
-                    <p className="text-xs text-muted-foreground break-words line-clamp-2">
+                    <p className="text-xs text-muted-foreground truncate">
                       {getUserRole(suggestion) || "No Role"}
                     </p>
                   </div>
                 </div>
 
-                <Link href={`/profile/${suggestion.unique_id}`}>
+                <Link
+                  href={`/profile/${suggestion.unique_id}`}
+                  className="flex-shrink-0"
+                >
                   <Button variant="outline" size="sm">
-                    <Eye className=" h-4 w-4" />
+                    <Eye className="h-4 w-4" />
                     View
                   </Button>
                 </Link>

--- a/src/components/Dashboard/posts/SharedPostView.tsx
+++ b/src/components/Dashboard/posts/SharedPostView.tsx
@@ -29,7 +29,7 @@ const SharedPostView: React.FC<SharedPostViewProps> = ({
 
   const post = posts.find((p) => p.id === initialPost.id) || initialPost
   const name = `${post.author.first_name} ${post.author.last_name}`
-  const effectiveSpaceId = spaceId || "shared"
+  const effectiveSpaceId = spaceId
 
   return (
     <Card className="bg-background shadow-lg max-w-2xl mx-auto">

--- a/src/components/Dashboard/posts/post-interactions.tsx
+++ b/src/components/Dashboard/posts/post-interactions.tsx
@@ -90,34 +90,22 @@ const PostInteractions: React.FC<Props> = ({
 
   return (
     <div className="flex justify-between w-full">
-      {spaceId !== "shared" ? (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleLike}
-          disabled={toggleLikeLoading}
-        >
-          <ThumbsUp
-            className={`mr-2 h-4 w-4 ${
-              isLiked
-                ? "text-primary dark:text-primary fill-primary dark:fill-white"
-                : ""
-            }`}
-          />
-          {likes}
-        </Button>
-      ) : (
-        <Button variant="ghost" size="sm">
-          <ThumbsUp
-            className={`mr-2 h-4 w-4 ${
-              isLiked
-                ? "text-primary dark:text-primary fill-primary dark:fill-white"
-                : ""
-            }`}
-          />
-          {likes}
-        </Button>
-      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleLike}
+        disabled={toggleLikeLoading}
+        className="group"
+      >
+        <ThumbsUp
+          className={`mr-2 h-4 w-4 ${
+            isLiked
+              ? "text-primary fill-primary group-hover:text-primary-foreground group-hover:fill-primary-foreground dark:text-primary dark:fill-white dark:group-hover:fill-white"
+              : ""
+          }`}
+        />
+        {likes}
+      </Button>
       <Button
         variant="ghost"
         size="sm"


### PR DESCRIPTION
## Summary
This PR fixes 2 UI bugs in the Posts module.

## Changes

### Fix 1: Long Profile Names in Suggested Connections
- Added text truncation with ellipsis for long profile names
- Fixed spacing between name and View button
- Prevented name from overlapping the View button

### Fix 2: Like Icon Disappears on Hover in Light Theme
- Fixed Like icon visibility on hover when post is already liked
- Added contrasting hover color so icon remains visible in Light Theme

## Issues Fixed
- Long profile names in Suggested Connections card were overlapping 
  the View button causing poor layout alignment
- Like icon was disappearing on hover in Light Theme due to icon 
  color matching the background

## Testing
- [ ] Tested long profile names in Suggested Connections — name truncates correctly
- [ ] Tested Like icon hover in Light Theme — icon remains visible
- [ ] like button in share page
