### PR TITLE
SW-286: Fix profile showing multiple roles after backend role update

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -331,7 +331,11 @@ export const formatRelativeTime = (
 
 export const getUserRole = (user: SelectUser, entity_id?: string) => {
   if (user.roles && user.roles.length > 0) {
-    if (entity_id) {
+    if (user.roles.some((ur) => ur.role?.role_type === "SYSTEM")) {
+      return user.roles.flatMap((ur) =>
+        ur.role && ur.role?.role_type === "SYSTEM" ? ur.role?.name : ""
+      )
+    } else if (entity_id) {
       return user.roles.flatMap((ur) =>
         ur.role &&
         ur.role.entity_id === entity_id &&
@@ -341,10 +345,7 @@ export const getUserRole = (user: SelectUser, entity_id?: string) => {
       )
     } else {
       return user.roles.flatMap((ur) =>
-        ur.role &&
-        (ur.role.role_type === "GLOBAL" || ur.role.role_type === "SYSTEM")
-          ? ur.role.name
-          : ""
+        ur.role && ur.role.role_type === "GLOBAL" ? ur.role.name : ""
       )
     }
   }


### PR DESCRIPTION
### Summary
This PR fixes an issue in the Profile module where multiple roles/personas were displayed together in the profile header.

If a user initially had a role such as `Student`, `Mentor`, or any other persona, and later became `Super_Admin` from the backend, the UI incorrectly displayed both roles together.

Examples:
- `Super_AdminStudent`
- `MentorSuper_Admin`

The profile header now displays only the effective active role.

---

### Issue
The UI was merging:
- Previously selected persona role
- Updated backend role

As a result, users who became `Super_Admin` still saw old persona labels alongside the current role.

---

### Fix Applied
- Updated profile role rendering logic
- Removed old/stale persona labels from the header
- Prioritized the effective backend role display
- Ensured `Super_Admin` is displayed alone even if the user previously had Student, Mentor, or any other role

---

### Expected Behavior
If a user has:
- Student → later becomes Super_Admin
- Mentor → later becomes Super_Admin
- Super_Admin + any previous persona

The UI should display only:
- `Super_Admin`

Previous persona labels should not appear together with the active role.

---

### Steps to Test
1. Create a new account with any persona:
   - Student
   - Mentor
   - Any other role
2. Login and verify profile role
3. Update the user role from backend/database to `Super_Admin`
4. Refresh the profile page
5. Verify only `Super_Admin` is displayed

---

### Result
✅ Only the active effective role is displayed  
✅ Previous persona labels are removed from the UI  
✅ Profile header remains consistent after backend role updates