### PR TITLE
Bug/sw 243 add read more button

### DIFF
--- a/src/components/Dashboard/posts/ExpandableText.tsx
+++ b/src/components/Dashboard/posts/ExpandableText.tsx
@@ -32,7 +32,9 @@ const ExpandableText: React.FC<Props> = ({
 
   return (
     <>
-      <MessageContent content={content} />
+      <div ref={contentRef} className={className} style={clampStyle}>
+        <MessageContent content={content} />
+      </div>
 
       {showToggle && (
         <Button

--- a/src/components/Dashboard/posts/post-image.tsx
+++ b/src/components/Dashboard/posts/post-image.tsx
@@ -15,6 +15,7 @@ import { UpdateCommentAction } from "@/src/server-actions/Post/Post"
 import { useToast } from "@/src/hooks/use-toast"
 import { useSetAtom } from "jotai"
 import { postStore } from "@/src/store/post/postStore"
+import ExpandableText from "./ExpandableText"
 
 type Props = {
   post: SelectFilePost
@@ -101,7 +102,7 @@ const ImagePost: React.FC<Props> = ({ post, spaceId }) => {
             {post.category}
           </Badge>
         )}
-        <p className="text-lg pb-5">{post.content}</p>
+        {post.content && <ExpandableText content={post?.content} lines={6} />}
 
         {/* Images */}
         {images.length > 0 && (


### PR DESCRIPTION
 **Title**

Fix missing “Read More” truncation behavior for image post captions

 **Description**

This PR adds truncation and expand/collapse behavior for long captions in image posts to align with the existing behavior of regular text posts.