### PR TITLE
Feature/sw 350 mentor on board

### DIFF
--- a/src/app/(dashboard)/profile/[id]/availability/page.tsx
+++ b/src/app/(dashboard)/profile/[id]/availability/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "next/navigation"
+import { AuthUserAction } from "@/src/server-actions/User/AuthUserAction"
+import { FindUserByUniqueIdAction } from "@/src/server-actions/User/FindUserByUniqueIdAction"
+import { AvailabilityPageShell } from "@/src/components/Dashboard/profile/AvailabilityPageShell"
+import NotFound from "@/src/components/Dashboard/NotFound/NotFound"
+
+interface Props {
+  params: Promise<{ id: string }>
+}
+
+export default async function ViewAvailabilityPage({ params }: Props) {
+  const { id } = await params
+  const authUser = await AuthUserAction()
+  if (!authUser) redirect("/sign-in")
+
+  if (authUser.unique_id === id) redirect("/profile/availability")
+
+  const userRes = await FindUserByUniqueIdAction(id)
+  if (userRes.error || !userRes.data) return <NotFound />
+
+  const mentor = userRes.data
+  const mentorName = `${mentor.first_name} ${mentor.last_name}`
+
+  return (
+    <AvailabilityPageShell
+      backHref={`/profile/${id}`}
+      title={`${mentorName}'s Availability`}
+      subtitle="View weekly recurring availability slots"
+      userId={id}
+      isMyProfile={false}
+    />
+  )
+}

--- a/src/app/(dashboard)/profile/availability/page.tsx
+++ b/src/app/(dashboard)/profile/availability/page.tsx
@@ -1,13 +1,13 @@
 import { redirect } from "next/navigation"
 import { AuthUserAction } from "@/src/server-actions/User/AuthUserAction"
 import { AvailabilityPageShell } from "@/src/components/Dashboard/profile/AvailabilityPageShell"
-import { isMentor } from "@/src/utils/helpers"
+import { getUserRole } from "@/src/utils/helpers"
 
 export default async function ManageAvailabilityPage() {
   const user = await AuthUserAction()
   if (!user) redirect("/sign-in")
 
-  if (!isMentor(user)) redirect("/profile")
+  if (!getUserRole(user)?.includes("Mentor")) redirect("/profile")
 
   return (
     <AvailabilityPageShell

--- a/src/app/(dashboard)/profile/availability/page.tsx
+++ b/src/app/(dashboard)/profile/availability/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "next/navigation"
+import { AuthUserAction } from "@/src/server-actions/User/AuthUserAction"
+import { AvailabilityPageShell } from "@/src/components/Dashboard/profile/AvailabilityPageShell"
+import { isMentor } from "@/src/utils/helpers"
+
+export default async function ManageAvailabilityPage() {
+  const user = await AuthUserAction()
+  if (!user) redirect("/sign-in")
+
+  if (!isMentor(user)) redirect("/profile")
+
+  return (
+    <AvailabilityPageShell
+      backHref="/profile"
+      title="Manage Availability"
+      subtitle="Set your weekly recurring availability slots"
+      userId={user.unique_id}
+      isMyProfile={true}
+    />
+  )
+}

--- a/src/components/Dashboard/profile/AvailabilityPageShell.tsx
+++ b/src/components/Dashboard/profile/AvailabilityPageShell.tsx
@@ -1,0 +1,40 @@
+import { ArrowLeft } from "lucide-react"
+import Link from "next/link"
+import { MentorCalendar } from "./MentorCalendar"
+
+interface AvailabilityPageShellProps {
+  backHref: string
+  title: string
+  subtitle: string
+  userId: string
+  isMyProfile: boolean
+}
+
+export function AvailabilityPageShell({
+  backHref,
+  title,
+  subtitle,
+  userId,
+  isMyProfile
+}: AvailabilityPageShellProps) {
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)] overflow-hidden">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-foreground/5 shrink-0">
+        <Link
+          href={backHref}
+          className="inline-flex items-center justify-center size-8 rounded-lg border border-transparent hover:bg-muted hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Link>
+        <div>
+          <h1 className="text-sm font-semibold">{title}</h1>
+          <p className="text-xs text-muted-foreground">{subtitle}</p>
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0">
+        <MentorCalendar userId={userId} isMyProfile={isMyProfile} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/Dashboard/profile/EditMentorModal.tsx
+++ b/src/components/Dashboard/profile/EditMentorModal.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from "../../ui/dialog"
+import { Button } from "../../ui/button"
+import { Label } from "../../ui/label"
+import { Input } from "../../ui/input"
+import { Controller, useForm } from "react-hook-form"
+import { z } from "zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { SelectProfile, SelectUser } from "@/src/db/schema"
+import { useServerAction } from "@/src/hooks/useServerAction"
+import { toast } from "@/src/hooks/use-toast"
+import { UnsavedChangesDialog } from "../../common/unsavedChangesDialog"
+import { useConfirmClose } from "@/src/hooks/useConfirmClose"
+import { SaveMentorSetupAction } from "@/src/server-actions/Mentor/MentorActions"
+
+interface Props {
+  user: SelectUser
+  profile: SelectProfile
+  setProfile: Dispatch<SetStateAction<SelectProfile | null | undefined>>
+}
+
+const mentorSchema = z.object({
+  professional_title: z
+    .string()
+    .min(1, "Title is required")
+    .max(100, "Maximum 100 characters"),
+  company: z
+    .string()
+    .min(1, "Company is required")
+    .max(100, "Maximum 100 characters")
+})
+
+type MentorFormValues = z.infer<typeof mentorSchema>
+
+function EditMentorModal({ user, profile, setProfile }: Props) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [loading, , , saveMentorSetup] = useServerAction(SaveMentorSetupAction)
+
+  const form = useForm<MentorFormValues>({
+    resolver: zodResolver(mentorSchema)
+  })
+
+  const {
+    formState: { errors, isDirty }
+  } = form
+
+  useEffect(() => {
+    if (!isDialogOpen) return
+    form.reset({
+      professional_title: profile?.professional_title || "",
+      company: profile?.company || ""
+    })
+  }, [isDialogOpen])
+
+  async function handleSubmit(data: MentorFormValues) {
+    const res = await saveMentorSetup({
+      userId: user.unique_id,
+      ...data
+    })
+
+    if (res?.success) {
+      setProfile((prev) =>
+        prev
+          ? {
+              ...prev,
+              professional_title: data.professional_title,
+              company: data.company
+            }
+          : prev
+      )
+      toast({ title: "Mentor profile updated", duration: 2000 })
+      setIsDialogOpen(false)
+    } else {
+      toast({
+        title: "Failed to update",
+        variant: "destructive",
+        duration: 2000
+      })
+    }
+  }
+
+  const { showConfirmation, setShowConfirmation, handleClose } =
+    useConfirmClose({
+      isDirty,
+      onClose: () => setIsDialogOpen(false)
+    })
+
+  const handleDialogChange = (open: boolean) => {
+    if (open) setIsDialogOpen(true)
+    else handleClose(false)
+  }
+
+  return (
+    <>
+      <Dialog open={isDialogOpen} onOpenChange={handleDialogChange}>
+        <DialogTrigger asChild>
+          <Button variant="edit" size="sm">
+            Edit
+          </Button>
+        </DialogTrigger>
+
+        <DialogContent
+          className="sm:max-w-[460px]"
+          onInteractOutside={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle>Edit Mentor Profile</DialogTitle>
+            <DialogDescription>
+              Update your professional details. Manage availability from your
+              profile calendar.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={form.handleSubmit(handleSubmit)}>
+            <div className="grid gap-4 py-4">
+              {/* Professional Title */}
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="professional_title" className="font-semibold">
+                  Professional Title
+                </Label>
+                <Controller
+                  name="professional_title"
+                  control={form.control}
+                  render={({ field }) => (
+                    <Input
+                      id="professional_title"
+                      placeholder="e.g. Senior Software Engineer"
+                      {...field}
+                    />
+                  )}
+                />
+                {errors.professional_title && (
+                  <span className="text-red-500 text-sm">
+                    {errors.professional_title.message}
+                  </span>
+                )}
+              </div>
+
+              {/* Company */}
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="company" className="font-semibold">
+                  Company / Organisation
+                </Label>
+                <Controller
+                  name="company"
+                  control={form.control}
+                  render={({ field }) => (
+                    <Input id="company" placeholder="e.g. Google" {...field} />
+                  )}
+                />
+                {errors.company && (
+                  <span className="text-red-500 text-sm">
+                    {errors.company.message}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button loading={loading}>Save changes</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <UnsavedChangesDialog
+        showConfirmation={showConfirmation}
+        setShowConfirmation={setShowConfirmation}
+        setIsActualDialogOpen={setIsDialogOpen}
+      />
+    </>
+  )
+}
+
+export default EditMentorModal

--- a/src/components/Dashboard/profile/MentorCalendar.tsx
+++ b/src/components/Dashboard/profile/MentorCalendar.tsx
@@ -25,35 +25,10 @@ import {
   UpdateAvailabilityAction
 } from "@/src/server-actions/Mentor/MentorActions"
 import { toast } from "@/src/hooks/use-toast"
-import { cn, toLocalDateStr } from "@/src/lib/utils"
+import { cn } from "@/src/lib/utils"
 import { SelectMentorAvailability } from "@/src/db/schema"
-
-const MONTH_NAMES = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December"
-]
-
-// Full day names used for labels; abbreviated headers derived from them
-const DAYS = [
-  "Sunday",
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday"
-]
-const DAY_HEADERS = DAYS.map((d) => d.slice(0, 3))
+import moment from "moment-timezone"
+import { DAY_HEADERS, DAYS, MONTH_NAMES } from "@/src/utils/constants"
 
 export const MIN_DURATION_MINS = 30
 
@@ -68,16 +43,9 @@ type SessionType = "1:1" | "group"
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function parseLocalDate(str: string): Date {
-  const [y, m, d] = str.split("-").map(Number)
-  return new Date(y, m - 1, d)
-}
-
+/** Format a HH:mm string to 12-hour display. */
 function formatTime(time: string) {
-  const [h, m] = time.split(":").map(Number)
-  const period = h >= 12 ? "PM" : "AM"
-  const hour = h % 12 || 12
-  return `${hour}:${m.toString().padStart(2, "0")} ${period}`
+  return moment(time, "HH:mm").format("h:mm A")
 }
 
 /** Returns true if this slot should appear on `date`. */
@@ -86,43 +54,39 @@ function slotAppliesToDate(
   date: Date
 ): boolean {
   if (!slot.date) return false
-  const anchor = parseLocalDate(slot.date)
-  anchor.setHours(0, 0, 0, 0)
-  const d = new Date(date)
-  d.setHours(0, 0, 0, 0)
+  const anchor = moment(slot.date, "YYYY-MM-DD")
+  const d = moment(date).startOf("day")
 
-  if (d < anchor) return false
+  if (d.isBefore(anchor)) return false
 
   if (slot.repeat_end_date) {
-    const endDate = parseLocalDate(slot.repeat_end_date)
-    endDate.setHours(0, 0, 0, 0)
-    if (d > endDate) return false
+    const endDate = moment(slot.repeat_end_date, "YYYY-MM-DD")
+    if (d.isAfter(endDate)) return false
   }
 
-  if (slot.repeat_type === "none") return toLocalDateStr(d) === slot.date
+  if (slot.repeat_type === "none") return d.format("YYYY-MM-DD") === slot.date
   if (slot.repeat_type === "daily") return true
-  if (slot.repeat_type === "weekly") return d.getDay() === anchor.getDay()
+  if (slot.repeat_type === "weekly") return d.day() === anchor.day()
   return false
 }
 
 function repeatLabel(slot: SelectMentorAvailability) {
   if (slot.repeat_type === "weekly")
-    return `Every ${DAYS[parseLocalDate(slot.date).getDay()]}`
+    return `Every ${DAYS[moment(slot.date, "YYYY-MM-DD").day()]}`
   if (slot.repeat_type === "daily") return "Every day"
   return "One-time"
 }
 
 /** Last day of the month containing `dateStr`. */
 function endOfMonth(dateStr: string): string {
-  const d = parseLocalDate(dateStr)
-  return toLocalDateStr(new Date(d.getFullYear(), d.getMonth() + 1, 0))
+  return moment(dateStr, "YYYY-MM-DD").endOf("month").format("YYYY-MM-DD")
 }
 
 /** First occurrence of `targetDow` (0=Sun) on or after `fromDateStr`. */
 function nextOccurrence(fromDateStr: string, targetDow: number): string {
-  const d = parseLocalDate(fromDateStr)
-  d.setDate(d.getDate() + ((targetDow - d.getDay() + 7) % 7))
-  return toLocalDateStr(d)
+  const m = moment(fromDateStr, "YYYY-MM-DD")
+  const diff = (targetDow - m.day() + 7) % 7
+  return m.clone().add(diff, "days").format("YYYY-MM-DD")
 }
 
 // ── Component ──────────────────────────────────────────────────────────────────
@@ -133,11 +97,7 @@ interface MentorCalendarProps {
 }
 
 // Stable reference — computed once at module load, not on every render
-const TODAY = (() => {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  return d
-})()
+const TODAY = moment().startOf("day").toDate()
 
 export function MentorCalendar({
   userId,
@@ -147,14 +107,14 @@ export function MentorCalendar({
 
   const [view, setView] = useState<ViewType>("month")
   const [currentDate, setCurrentDate] = useState(
-    new Date(today.getFullYear(), today.getMonth(), 1)
+    moment(today).startOf("month").toDate()
   )
   const [slots, setSlots] = useState<SelectMentorAvailability[]>([])
 
   // Popup state
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [isPopupOpen, setIsPopupOpen] = useState(false)
-  const [newDate, setNewDate] = useState(toLocalDateStr(today))
+  const [newDate, setNewDate] = useState(moment(today).format("YYYY-MM-DD"))
   const [newStart, setNewStart] = useState("09:00")
   const [newEnd, setNewEnd] = useState("10:00")
   const [newSession, setNewSession] = useState<SessionType>("1:1")
@@ -163,13 +123,14 @@ export function MentorCalendar({
   const [newRepeatEnd, setNewRepeatEnd] = useState("")
   const [slotError, setSlotError] = useState("")
   const [saving, setSaving] = useState(false)
+  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null)
 
   const [, , , getAvailability] = useServerAction(GetMentorAvailabilityAction)
   const [, , , updateAvailability] = useServerAction(UpdateAvailabilityAction)
 
   const loadSlots = useCallback(async () => {
     const res = await getAvailability(userId)
-    if (res?.success && res.data) setSlots(res.data.filter((s) => s.is_active))
+    if (res?.success) setSlots((res.data ?? []).filter((s) => s.is_active))
   }, [userId])
 
   useEffect(() => {
@@ -181,75 +142,65 @@ export function MentorCalendar({
   const goBack = () => {
     if (view === "month") {
       setCurrentDate(
-        new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1)
+        moment(currentDate).subtract(1, "month").startOf("month").toDate()
       )
     } else {
-      const d = new Date(currentDate)
-      d.setDate(d.getDate() - 7)
-      setCurrentDate(d)
+      setCurrentDate(moment(currentDate).subtract(7, "days").toDate())
     }
   }
 
   const goForward = () => {
     if (view === "month") {
       setCurrentDate(
-        new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1)
+        moment(currentDate).add(1, "month").startOf("month").toDate()
       )
     } else {
-      const d = new Date(currentDate)
-      d.setDate(d.getDate() + 7)
-      setCurrentDate(d)
+      setCurrentDate(moment(currentDate).add(7, "days").toDate())
     }
   }
 
   const goToday = () => {
     if (view === "month") {
-      setCurrentDate(new Date(today.getFullYear(), today.getMonth(), 1))
+      setCurrentDate(moment(today).startOf("month").toDate())
     } else {
-      const s = new Date(today)
-      s.setDate(today.getDate() - today.getDay())
-      setCurrentDate(s)
+      setCurrentDate(moment(today).startOf("week").toDate())
     }
   }
 
   const switchView = (v: ViewType) => {
     setView(v)
     if (v === "week") {
-      const s = new Date(today)
-      s.setDate(today.getDate() - today.getDay())
-      setCurrentDate(s)
+      setCurrentDate(moment(today).startOf("week").toDate())
     } else {
-      setCurrentDate(new Date(today.getFullYear(), today.getMonth(), 1))
+      setCurrentDate(moment(today).startOf("month").toDate())
     }
   }
 
   // ── Calendar cells ────────────────────────────────────────────────────────────
 
   const monthWeeks = useMemo(() => {
-    const y = currentDate.getFullYear(),
-      mo = currentDate.getMonth()
-    const first = new Date(y, mo, 1).getDay()
-    const dim = new Date(y, mo + 1, 0).getDate()
-    const prev = new Date(y, mo, 0).getDate()
+    const m = moment(currentDate).startOf("month")
+    const first = m.day()
+    const dim = m.daysInMonth()
+    const prevEnd = m.clone().subtract(1, "day")
     const cells: Date[] = []
     for (let i = first - 1; i >= 0; i--)
-      cells.push(new Date(y, mo - 1, prev - i))
-    for (let d = 1; d <= dim; d++) cells.push(new Date(y, mo, d))
+      cells.push(prevEnd.clone().subtract(i, "days").toDate())
+    for (let d = 1; d <= dim; d++) cells.push(m.clone().date(d).toDate())
     const rem = 42 - cells.length
-    for (let d = 1; d <= rem; d++) cells.push(new Date(y, mo + 1, d))
+    const nextStart = m.clone().add(1, "month").startOf("month")
+    for (let d = 1; d <= rem; d++)
+      cells.push(nextStart.clone().date(d).toDate())
     const weeks: Date[][] = []
     for (let i = 0; i < 42; i += 7) weeks.push(cells.slice(i, i + 7))
     return weeks
   }, [currentDate])
 
   const weekDays = useMemo(() => {
-    const s = new Date(currentDate)
-    s.setDate(s.getDate() - s.getDay())
-    return Array.from({ length: 7 }, (_, i) => {
-      const d = new Date(s)
-      d.setDate(s.getDate() + i)
-      return d
-    })
+    const startOfWeek = moment(currentDate).startOf("week")
+    return Array.from({ length: 7 }, (_, i) =>
+      startOfWeek.clone().add(i, "days").toDate()
+    )
   }, [currentDate])
 
   // ── Slot helpers ──────────────────────────────────────────────────────────────
@@ -258,7 +209,8 @@ export function MentorCalendar({
     slots.filter((s) => slotAppliesToDate(s, date))
 
   const resetPopupForm = (date: Date) => {
-    const dateStr = toLocalDateStr(date)
+    setPendingDeleteId(null)
+    const dateStr = moment(date).format("YYYY-MM-DD")
     setNewDate(dateStr)
     setNewStart("09:00")
     setNewEnd("10:00")
@@ -290,13 +242,13 @@ export function MentorCalendar({
       return
     }
 
-    // Overlap check — two slots conflict if they share at least one day AND their times overlap
+    // Overlap check — slots conflict if they share a day, overlapping times, AND overlapping date ranges
     const timesOverlap = (s: SelectMentorAvailability) =>
       toMins(newStart) < toMins(s.end_time) &&
       toMins(s.start_time) < toMins(newEnd)
 
     const dayOverlaps = (s: SelectMentorAvailability, dow: number) => {
-      const sDow = parseLocalDate(s.date).getDay()
+      const sDow = moment(s.date, "YYYY-MM-DD").day()
       if (s.repeat_type === "daily") return true
       if (s.repeat_type === "none") {
         if (newRepeat === "none") return s.date === newDate
@@ -305,15 +257,28 @@ export function MentorCalendar({
       }
       if (s.repeat_type === "weekly") {
         if (newRepeat === "none")
-          return sDow === parseLocalDate(newDate).getDay()
+          return sDow === moment(newDate, "YYYY-MM-DD").day()
         if (newRepeat === "daily") return true
         if (newRepeat === "weekly") return sDow === dow
       }
       return false
     }
 
+    const dateRangesOverlap = (s: SelectMentorAvailability, dow: number) => {
+      const existingStart = s.date
+      const existingEnd = s.repeat_end_date ?? "9999-12-31"
+      const newFirst =
+        newRepeat === "weekly" ? nextOccurrence(newDate, dow) : newDate
+      const newLast =
+        newRepeat !== "none" ? newRepeatEnd || endOfMonth(newDate) : newDate
+      return newFirst <= existingEnd && existingStart <= newLast
+    }
+
     const hasConflict = (dow: number) =>
-      slots.some((s) => dayOverlaps(s, dow) && timesOverlap(s))
+      slots.some(
+        (s) =>
+          dayOverlaps(s, dow) && timesOverlap(s) && dateRangesOverlap(s, dow)
+      )
 
     if (newRepeat === "weekly") {
       const conflicting = newRepeatDays
@@ -324,7 +289,7 @@ export function MentorCalendar({
         return
       }
     } else {
-      if (hasConflict(parseLocalDate(newDate).getDay())) {
+      if (hasConflict(moment(newDate, "YYYY-MM-DD").day())) {
         setSlotError("This slot overlaps with an existing one")
         return
       }
@@ -381,21 +346,85 @@ export function MentorCalendar({
     setSaving(false)
   }
 
-  const handleRemoveSlot = async (slotId: number) => {
-    const remaining = slots
-      .filter((s) => s.id !== slotId)
-      .map((s) => ({
-        date: s.date,
-        start_time: s.start_time,
-        end_time: s.end_time,
-        session_type: s.session_type,
-        repeat_type: s.repeat_type,
-        repeat_end_date: s.repeat_end_date ?? null
-      }))
+  const serializeSlots = (list: SelectMentorAvailability[]) =>
+    list.map((s) => ({
+      date: s.date,
+      start_time: s.start_time,
+      end_time: s.end_time,
+      session_type: s.session_type,
+      repeat_type: s.repeat_type,
+      repeat_end_date: s.repeat_end_date ?? null
+    }))
+
+  /** Remove the entire recurring series (or a one-time slot). */
+  const handleDeleteSeries = async (slotId: number) => {
+    setPendingDeleteId(null)
+    setSlotError("")
+    const remaining = serializeSlots(slots.filter((s) => s.id !== slotId))
     const res = await updateAvailability({ mentorId: userId, slots: remaining })
     if (res?.success) {
-      setSlots((p) => p.filter((s) => s.id !== slotId))
+      setSlots([])
+      await loadSlots()
+      if (selectedDate) resetPopupForm(selectedDate)
       toast({ title: "Slot removed", duration: 2000 })
+    }
+  }
+
+  /** Remove only the occurrence on `date`, keeping the rest of the series intact. */
+  const handleDeleteOccurrence = async (slotId: number, date: Date) => {
+    setPendingDeleteId(null)
+    setSlotError("")
+    const slot = slots.find((s) => s.id === slotId)
+    if (!slot) return
+
+    const dow = moment(slot.date, "YYYY-MM-DD").day()
+    const occStr = moment(date).format("YYYY-MM-DD")
+
+    // Day before this occurrence → previous series ends here
+    const prevStr = moment(date).subtract(1, "day").format("YYYY-MM-DD")
+
+    // Day after this occurrence → next series starts here
+    const afterStr = moment(date).add(1, "day").format("YYYY-MM-DD")
+    const nextStr =
+      slot.repeat_type === "daily" ? afterStr : nextOccurrence(afterStr, dow)
+
+    const otherSlots = serializeSlots(slots.filter((s) => s.id !== slotId))
+    const additions: typeof otherSlots = []
+
+    // Keep everything BEFORE this occurrence (only if anchor < occurrence)
+    if (slot.date < occStr) {
+      additions.push({
+        date: slot.date,
+        start_time: slot.start_time,
+        end_time: slot.end_time,
+        session_type: slot.session_type,
+        repeat_type: slot.repeat_type,
+        repeat_end_date: prevStr
+      })
+    }
+
+    // Keep everything AFTER this occurrence (only if a next occurrence exists within the original end)
+    const originalEnd = slot.repeat_end_date ?? null
+    if (!originalEnd || nextStr <= originalEnd) {
+      additions.push({
+        date: nextStr,
+        start_time: slot.start_time,
+        end_time: slot.end_time,
+        session_type: slot.session_type,
+        repeat_type: slot.repeat_type,
+        repeat_end_date: originalEnd
+      })
+    }
+
+    const res = await updateAvailability({
+      mentorId: userId,
+      slots: [...otherSlots, ...additions]
+    })
+    if (res?.success) {
+      setSlots([])
+      await loadSlots()
+      if (selectedDate) resetPopupForm(selectedDate)
+      toast({ title: "Occurrence removed", duration: 2000 })
     }
   }
 
@@ -715,7 +744,10 @@ export function MentorCalendar({
                         <button
                           key={r}
                           type="button"
-                          onClick={() => setNewRepeat(r)}
+                          onClick={() => {
+                            setNewRepeat(r)
+                            setSlotError("")
+                          }}
                           className={toggleItemCls(
                             newRepeat === r,
                             i === 0,
@@ -802,34 +834,74 @@ export function MentorCalendar({
                   {slotsForSelected.map((slot) => (
                     <div
                       key={slot.id}
-                      className="flex items-center justify-between rounded-lg border border-foreground/8 px-3 py-2.5 text-sm"
+                      className="rounded-lg border border-foreground/8 text-sm overflow-hidden"
                     >
-                      <div className="flex items-center gap-2.5 min-w-0">
-                        {slot.session_type === "group" ? (
-                          <Users className="h-4 w-4 text-muted-foreground shrink-0" />
-                        ) : (
-                          <Video className="h-4 w-4 text-muted-foreground shrink-0" />
-                        )}
-                        <div className="min-w-0">
-                          <p className="truncate">
-                            {formatTime(slot.start_time)} –{" "}
-                            {formatTime(slot.end_time)}
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            {repeatLabel(slot)}
-                          </p>
+                      {/* Slot info row */}
+                      <div className="flex items-center justify-between px-3 py-2.5">
+                        <div className="flex items-center gap-2.5 min-w-0">
+                          {slot.session_type === "group" ? (
+                            <Users className="h-4 w-4 text-muted-foreground shrink-0" />
+                          ) : (
+                            <Video className="h-4 w-4 text-muted-foreground shrink-0" />
+                          )}
+                          <div className="min-w-0">
+                            <p className="truncate">
+                              {formatTime(slot.start_time)} –{" "}
+                              {formatTime(slot.end_time)}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {repeatLabel(slot)}
+                            </p>
+                          </div>
+                          <span className="text-xs text-muted-foreground border border-foreground/10 rounded px-1.5 py-0.5 shrink-0">
+                            {slot.session_type === "group" ? "Group" : "1-on-1"}
+                          </span>
                         </div>
-                        <span className="text-xs text-muted-foreground border border-foreground/10 rounded px-1.5 py-0.5 shrink-0">
-                          {slot.session_type === "group" ? "Group" : "1-on-1"}
-                        </span>
+                        {isMyProfile && (
+                          <button
+                            onClick={() => {
+                              if (slot.repeat_type === "none") {
+                                handleDeleteSeries(slot.id)
+                              } else {
+                                setPendingDeleteId(
+                                  pendingDeleteId === slot.id ? null : slot.id
+                                )
+                              }
+                            }}
+                            className="h-6 w-6 flex items-center justify-center shrink-0 rounded text-destructive hover:bg-destructive/10 transition-colors ml-2"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        )}
                       </div>
-                      {isMyProfile && (
-                        <button
-                          onClick={() => handleRemoveSlot(slot.id)}
-                          className="h-6 w-6 flex items-center justify-center shrink-0 rounded text-destructive hover:bg-destructive/10 transition-colors ml-2"
-                        >
-                          <X className="h-3.5 w-3.5" />
-                        </button>
+
+                      {/* Inline delete confirmation — only for recurring slots */}
+                      {isMyProfile && pendingDeleteId === slot.id && (
+                        <div className="flex items-center gap-2 px-3 py-2 border-t border-foreground/8 bg-destructive/5">
+                          <p className="text-xs text-muted-foreground flex-1">
+                            Remove:
+                          </p>
+                          <button
+                            onClick={() =>
+                              handleDeleteOccurrence(slot.id, selectedDate!)
+                            }
+                            className="text-xs px-2 py-1 rounded border border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors whitespace-nowrap"
+                          >
+                            This date
+                          </button>
+                          <button
+                            onClick={() => handleDeleteSeries(slot.id)}
+                            className="text-xs px-2 py-1 rounded bg-destructive text-destructive-foreground hover:bg-destructive/80 transition-colors whitespace-nowrap"
+                          >
+                            All dates
+                          </button>
+                          <button
+                            onClick={() => setPendingDeleteId(null)}
+                            className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground hover:text-foreground transition-colors"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </div>
                       )}
                     </div>
                   ))}

--- a/src/components/Dashboard/profile/MentorCalendar.tsx
+++ b/src/components/Dashboard/profile/MentorCalendar.tsx
@@ -1,0 +1,868 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Button } from "@/src/components/ui/button"
+import { Input } from "@/src/components/ui/input"
+import { Label } from "@/src/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from "../../ui/dialog"
+import {
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  RefreshCw,
+  Users,
+  Video,
+  X
+} from "lucide-react"
+import { useServerAction } from "@/src/hooks/useServerAction"
+import {
+  GetMentorAvailabilityAction,
+  UpdateAvailabilityAction
+} from "@/src/server-actions/Mentor/MentorActions"
+import { toast } from "@/src/hooks/use-toast"
+import { cn, toLocalDateStr } from "@/src/lib/utils"
+import { SelectMentorAvailability } from "@/src/db/schema"
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+]
+
+// Full day names used for labels; abbreviated headers derived from them
+const DAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday"
+]
+const DAY_HEADERS = DAYS.map((d) => d.slice(0, 3))
+
+export const MIN_DURATION_MINS = 30
+
+export function toMins(time: string) {
+  const [h, m] = time.split(":").map(Number)
+  return h * 60 + m
+}
+
+type ViewType = "month" | "week"
+type RepeatType = "none" | "daily" | "weekly"
+type SessionType = "1:1" | "group"
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function parseLocalDate(str: string): Date {
+  const [y, m, d] = str.split("-").map(Number)
+  return new Date(y, m - 1, d)
+}
+
+function formatTime(time: string) {
+  const [h, m] = time.split(":").map(Number)
+  const period = h >= 12 ? "PM" : "AM"
+  const hour = h % 12 || 12
+  return `${hour}:${m.toString().padStart(2, "0")} ${period}`
+}
+
+/** Returns true if this slot should appear on `date`. */
+function slotAppliesToDate(
+  slot: SelectMentorAvailability,
+  date: Date
+): boolean {
+  if (!slot.date) return false
+  const anchor = parseLocalDate(slot.date)
+  anchor.setHours(0, 0, 0, 0)
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+
+  if (d < anchor) return false
+
+  if (slot.repeat_end_date) {
+    const endDate = parseLocalDate(slot.repeat_end_date)
+    endDate.setHours(0, 0, 0, 0)
+    if (d > endDate) return false
+  }
+
+  if (slot.repeat_type === "none") return toLocalDateStr(d) === slot.date
+  if (slot.repeat_type === "daily") return true
+  if (slot.repeat_type === "weekly") return d.getDay() === anchor.getDay()
+  return false
+}
+
+function repeatLabel(slot: SelectMentorAvailability) {
+  if (slot.repeat_type === "weekly")
+    return `Every ${DAYS[parseLocalDate(slot.date).getDay()]}`
+  if (slot.repeat_type === "daily") return "Every day"
+  return "One-time"
+}
+
+/** Last day of the month containing `dateStr`. */
+function endOfMonth(dateStr: string): string {
+  const d = parseLocalDate(dateStr)
+  return toLocalDateStr(new Date(d.getFullYear(), d.getMonth() + 1, 0))
+}
+
+/** First occurrence of `targetDow` (0=Sun) on or after `fromDateStr`. */
+function nextOccurrence(fromDateStr: string, targetDow: number): string {
+  const d = parseLocalDate(fromDateStr)
+  d.setDate(d.getDate() + ((targetDow - d.getDay() + 7) % 7))
+  return toLocalDateStr(d)
+}
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+interface MentorCalendarProps {
+  userId: string
+  isMyProfile?: boolean
+}
+
+// Stable reference — computed once at module load, not on every render
+const TODAY = (() => {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+})()
+
+export function MentorCalendar({
+  userId,
+  isMyProfile = false
+}: MentorCalendarProps) {
+  const today = TODAY
+
+  const [view, setView] = useState<ViewType>("month")
+  const [currentDate, setCurrentDate] = useState(
+    new Date(today.getFullYear(), today.getMonth(), 1)
+  )
+  const [slots, setSlots] = useState<SelectMentorAvailability[]>([])
+
+  // Popup state
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  const [isPopupOpen, setIsPopupOpen] = useState(false)
+  const [newDate, setNewDate] = useState(toLocalDateStr(today))
+  const [newStart, setNewStart] = useState("09:00")
+  const [newEnd, setNewEnd] = useState("10:00")
+  const [newSession, setNewSession] = useState<SessionType>("1:1")
+  const [newRepeat, setNewRepeat] = useState<RepeatType>("weekly")
+  const [newRepeatDays, setNewRepeatDays] = useState<number[]>([today.getDay()])
+  const [newRepeatEnd, setNewRepeatEnd] = useState("")
+  const [slotError, setSlotError] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const [, , , getAvailability] = useServerAction(GetMentorAvailabilityAction)
+  const [, , , updateAvailability] = useServerAction(UpdateAvailabilityAction)
+
+  const loadSlots = useCallback(async () => {
+    const res = await getAvailability(userId)
+    if (res?.success && res.data) setSlots(res.data.filter((s) => s.is_active))
+  }, [userId])
+
+  useEffect(() => {
+    loadSlots()
+  }, [loadSlots])
+
+  // ── Navigation ────────────────────────────────────────────────────────────────
+
+  const goBack = () => {
+    if (view === "month") {
+      setCurrentDate(
+        new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1)
+      )
+    } else {
+      const d = new Date(currentDate)
+      d.setDate(d.getDate() - 7)
+      setCurrentDate(d)
+    }
+  }
+
+  const goForward = () => {
+    if (view === "month") {
+      setCurrentDate(
+        new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 1)
+      )
+    } else {
+      const d = new Date(currentDate)
+      d.setDate(d.getDate() + 7)
+      setCurrentDate(d)
+    }
+  }
+
+  const goToday = () => {
+    if (view === "month") {
+      setCurrentDate(new Date(today.getFullYear(), today.getMonth(), 1))
+    } else {
+      const s = new Date(today)
+      s.setDate(today.getDate() - today.getDay())
+      setCurrentDate(s)
+    }
+  }
+
+  const switchView = (v: ViewType) => {
+    setView(v)
+    if (v === "week") {
+      const s = new Date(today)
+      s.setDate(today.getDate() - today.getDay())
+      setCurrentDate(s)
+    } else {
+      setCurrentDate(new Date(today.getFullYear(), today.getMonth(), 1))
+    }
+  }
+
+  // ── Calendar cells ────────────────────────────────────────────────────────────
+
+  const monthWeeks = useMemo(() => {
+    const y = currentDate.getFullYear(),
+      mo = currentDate.getMonth()
+    const first = new Date(y, mo, 1).getDay()
+    const dim = new Date(y, mo + 1, 0).getDate()
+    const prev = new Date(y, mo, 0).getDate()
+    const cells: Date[] = []
+    for (let i = first - 1; i >= 0; i--)
+      cells.push(new Date(y, mo - 1, prev - i))
+    for (let d = 1; d <= dim; d++) cells.push(new Date(y, mo, d))
+    const rem = 42 - cells.length
+    for (let d = 1; d <= rem; d++) cells.push(new Date(y, mo + 1, d))
+    const weeks: Date[][] = []
+    for (let i = 0; i < 42; i += 7) weeks.push(cells.slice(i, i + 7))
+    return weeks
+  }, [currentDate])
+
+  const weekDays = useMemo(() => {
+    const s = new Date(currentDate)
+    s.setDate(s.getDate() - s.getDay())
+    return Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(s)
+      d.setDate(s.getDate() + i)
+      return d
+    })
+  }, [currentDate])
+
+  // ── Slot helpers ──────────────────────────────────────────────────────────────
+
+  const getSlotsForDate = (date: Date) =>
+    slots.filter((s) => slotAppliesToDate(s, date))
+
+  const resetPopupForm = (date: Date) => {
+    const dateStr = toLocalDateStr(date)
+    setNewDate(dateStr)
+    setNewStart("09:00")
+    setNewEnd("10:00")
+    setNewSession("1:1")
+    setNewRepeat("weekly")
+    setNewRepeatDays([date.getDay()])
+    setNewRepeatEnd(endOfMonth(dateStr))
+    setSlotError("")
+  }
+
+  const openPopup = (date: Date) => {
+    if (!isMyProfile && getSlotsForDate(date).length === 0) return
+    setSelectedDate(date)
+    resetPopupForm(date)
+    setIsPopupOpen(true)
+  }
+
+  const handleAddSlot = async () => {
+    if (toMins(newEnd) <= toMins(newStart)) {
+      setSlotError("End time must be after start time")
+      return
+    }
+    if (toMins(newEnd) - toMins(newStart) < MIN_DURATION_MINS) {
+      setSlotError(`Minimum ${MIN_DURATION_MINS} minutes`)
+      return
+    }
+    if (newRepeat === "weekly" && newRepeatDays.length === 0) {
+      setSlotError("Select at least one day")
+      return
+    }
+
+    // Overlap check — two slots conflict if they share at least one day AND their times overlap
+    const timesOverlap = (s: SelectMentorAvailability) =>
+      toMins(newStart) < toMins(s.end_time) &&
+      toMins(s.start_time) < toMins(newEnd)
+
+    const dayOverlaps = (s: SelectMentorAvailability, dow: number) => {
+      const sDow = parseLocalDate(s.date).getDay()
+      if (s.repeat_type === "daily") return true
+      if (s.repeat_type === "none") {
+        if (newRepeat === "none") return s.date === newDate
+        if (newRepeat === "daily") return true
+        if (newRepeat === "weekly") return sDow === dow
+      }
+      if (s.repeat_type === "weekly") {
+        if (newRepeat === "none")
+          return sDow === parseLocalDate(newDate).getDay()
+        if (newRepeat === "daily") return true
+        if (newRepeat === "weekly") return sDow === dow
+      }
+      return false
+    }
+
+    const hasConflict = (dow: number) =>
+      slots.some((s) => dayOverlaps(s, dow) && timesOverlap(s))
+
+    if (newRepeat === "weekly") {
+      const conflicting = newRepeatDays
+        .filter((dow) => hasConflict(dow))
+        .map((dow) => DAY_HEADERS[dow])
+      if (conflicting.length > 0) {
+        setSlotError(`Overlapping slot exists for: ${conflicting.join(", ")}`)
+        return
+      }
+    } else {
+      if (hasConflict(parseLocalDate(newDate).getDay())) {
+        setSlotError("This slot overlaps with an existing one")
+        return
+      }
+    }
+
+    setSaving(true)
+    const repeatEnd =
+      newRepeat !== "none" ? newRepeatEnd || endOfMonth(newDate) : null
+
+    const newSlots =
+      newRepeat === "weekly"
+        ? newRepeatDays.map((dow) => ({
+            date: nextOccurrence(newDate, dow),
+            start_time: newStart,
+            end_time: newEnd,
+            session_type: newSession,
+            repeat_type: "weekly" as RepeatType,
+            repeat_end_date: repeatEnd
+          }))
+        : [
+            {
+              date: newDate,
+              start_time: newStart,
+              end_time: newEnd,
+              session_type: newSession,
+              repeat_type: newRepeat,
+              repeat_end_date: repeatEnd
+            }
+          ]
+
+    const existing = slots.map((s) => ({
+      date: s.date,
+      start_time: s.start_time,
+      end_time: s.end_time,
+      session_type: s.session_type,
+      repeat_type: s.repeat_type,
+      repeat_end_date: s.repeat_end_date ?? null
+    }))
+
+    const res = await updateAvailability({
+      mentorId: userId,
+      slots: [...existing, ...newSlots]
+    })
+    if (res?.success) {
+      await loadSlots()
+      toast({ title: "Slot added", duration: 2000 })
+    } else {
+      toast({
+        title: "Failed to add slot",
+        variant: "destructive",
+        duration: 2000
+      })
+    }
+    setSaving(false)
+  }
+
+  const handleRemoveSlot = async (slotId: number) => {
+    const remaining = slots
+      .filter((s) => s.id !== slotId)
+      .map((s) => ({
+        date: s.date,
+        start_time: s.start_time,
+        end_time: s.end_time,
+        session_type: s.session_type,
+        repeat_type: s.repeat_type,
+        repeat_end_date: s.repeat_end_date ?? null
+      }))
+    const res = await updateAvailability({ mentorId: userId, slots: remaining })
+    if (res?.success) {
+      setSlots((p) => p.filter((s) => s.id !== slotId))
+      toast({ title: "Slot removed", duration: 2000 })
+    }
+  }
+
+  // ── Derived values ────────────────────────────────────────────────────────────
+
+  const year = currentDate.getFullYear(),
+    month = currentDate.getMonth()
+
+  const headerLabel = useMemo(() => {
+    if (view === "month") return `${MONTH_NAMES[month]} ${year}`
+    const s = weekDays[0],
+      e = weekDays[6]
+    if (!s || !e) return ""
+    return s.getMonth() === e.getMonth()
+      ? `${MONTH_NAMES[s.getMonth()]} ${s.getDate()} – ${e.getDate()}, ${s.getFullYear()}`
+      : `${MONTH_NAMES[s.getMonth()]} ${s.getDate()} – ${MONTH_NAMES[e.getMonth()]} ${e.getDate()}, ${e.getFullYear()}`
+  }, [view, month, year, weekDays])
+
+  const isCurrentMonth = (d: Date) =>
+    d.getMonth() === month && d.getFullYear() === year
+  const isToday = (d: Date) => d.toDateString() === today.toDateString()
+  const slotsForSelected = selectedDate ? getSlotsForDate(selectedDate) : []
+  const selectedDayName = selectedDate ? DAYS[selectedDate.getDay()] : ""
+
+  // ── Reusable toggle class helper ──────────────────────────────────────────────
+
+  const toggleItemCls = (
+    active: boolean,
+    first: boolean,
+    extraPad = "px-3 py-1.5"
+  ) =>
+    cn(
+      extraPad,
+      "text-xs font-medium transition-colors",
+      !first && "border-l border-foreground/10",
+      active
+        ? "bg-primary text-primary-foreground"
+        : "hover:bg-muted text-muted-foreground"
+    )
+
+  // ── Cell render ───────────────────────────────────────────────────────────────
+
+  const renderCell = (date: Date, inMonth: boolean) => {
+    const daySlots = getSlotsForDate(date)
+    const clickable = isMyProfile || daySlots.length > 0
+    return (
+      <div
+        key={date.toISOString()}
+        onClick={() => openPopup(date)}
+        className={cn(
+          "border-r border-foreground/5 last:border-r-0 p-1 flex flex-col gap-0.5 transition-colors min-h-0 overflow-hidden",
+          clickable
+            ? "cursor-pointer hover:bg-foreground/[0.02]"
+            : "cursor-default",
+          !inMonth && "opacity-40"
+        )}
+      >
+        <div className="flex items-center justify-start">
+          <span
+            className={cn(
+              "text-xs w-6 h-6 flex items-center justify-center rounded-full font-medium",
+              isToday(date)
+                ? "bg-primary text-primary-foreground"
+                : "text-foreground"
+            )}
+          >
+            {date.getDate()}
+          </span>
+        </div>
+        {daySlots.slice(0, 2).map((slot) => (
+          <div
+            key={slot.id}
+            title={`${slot.session_type === "group" ? "Group" : "1-on-1"} · ${formatTime(slot.start_time)} – ${formatTime(slot.end_time)}`}
+            className="text-[10px] leading-tight truncate rounded px-1 py-0.5 bg-primary/20 text-primary font-medium flex items-center gap-0.5"
+          >
+            {slot.session_type === "group" ? (
+              <Users className="h-2.5 w-2.5 shrink-0" />
+            ) : (
+              <Video className="h-2.5 w-2.5 shrink-0" />
+            )}
+            {formatTime(slot.start_time)}
+          </div>
+        ))}
+        {daySlots.length > 2 && (
+          <span className="text-[10px] text-muted-foreground px-1">
+            +{daySlots.length - 2} more
+          </span>
+        )}
+      </div>
+    )
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* ── Header ── */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between px-4 py-3 border-b border-foreground/5 shrink-0 gap-2">
+        {/* Left: nav + title */}
+        <div className="flex items-center justify-between sm:justify-start gap-3">
+          <div className="flex items-center gap-1">
+            <button
+              onClick={goBack}
+              className="inline-flex shrink-0 items-center justify-center size-8 rounded-lg border border-transparent hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              onClick={goToday}
+              className="inline-flex shrink-0 items-center justify-center h-7 px-2.5 rounded-[min(var(--radius-md),12px)] border border-transparent text-xs font-medium hover:bg-muted hover:text-foreground transition-colors"
+            >
+              Today
+            </button>
+            <button
+              onClick={goForward}
+              className="inline-flex shrink-0 items-center justify-center size-8 rounded-lg border border-transparent hover:bg-muted hover:text-foreground transition-colors"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+          <h2 className="text-sm font-semibold truncate">{headerLabel}</h2>
+
+          {/* Month/Week toggle — visible on mobile inside left row */}
+          <div className="flex sm:hidden rounded-md border border-foreground/10 overflow-hidden ml-auto">
+            {(["month", "week"] as ViewType[]).map((v, i) => (
+              <button
+                key={v}
+                onClick={() => switchView(v)}
+                className={toggleItemCls(
+                  view === v,
+                  i === 0,
+                  "px-2.5 py-1.5 capitalize"
+                )}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Right: toggle (desktop) + New Slot */}
+        <div className="flex items-center gap-2">
+          <div className="hidden sm:flex rounded-md border border-foreground/10 overflow-hidden">
+            {(["month", "week"] as ViewType[]).map((v, i) => (
+              <button
+                key={v}
+                onClick={() => switchView(v)}
+                className={toggleItemCls(
+                  view === v,
+                  i === 0,
+                  "px-3 py-1.5 capitalize"
+                )}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+
+          {isMyProfile && (
+            <button
+              onClick={() => {
+                setSelectedDate(today)
+                resetPopupForm(today)
+                setIsPopupOpen(true)
+              }}
+              className="inline-flex items-center justify-center gap-1.5 h-7 px-2.5 rounded-[min(var(--radius-md),12px)] bg-primary text-primary-foreground text-[0.8rem] font-medium transition-colors hover:bg-primary/80 whitespace-nowrap"
+            >
+              <Plus className="h-4 w-4" />
+              <span className="hidden sm:inline">New Slot</span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Body ── */}
+      <div className="flex-1 overflow-hidden min-h-0">
+        <div className="flex flex-col h-full">
+          <div className="grid grid-cols-7 border-b border-foreground/5 shrink-0">
+            {DAY_HEADERS.map((d) => (
+              <div
+                key={d}
+                className="py-2 text-center text-xs font-semibold text-muted-foreground uppercase tracking-wider"
+              >
+                {d}
+              </div>
+            ))}
+          </div>
+
+          {view === "month" && (
+            <div className="flex-1 grid grid-rows-6 overflow-hidden">
+              {monthWeeks.map((week, wi) => (
+                <div
+                  key={wi}
+                  className="grid grid-cols-7 border-b border-foreground/5 last:border-b-0 min-h-0"
+                >
+                  {week.map((date) => renderCell(date, isCurrentMonth(date)))}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {view === "week" && (
+            <div className="flex-1 overflow-hidden">
+              <div className="grid grid-cols-7 h-full">
+                {weekDays.map((date) => renderCell(date, true))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Popup ── */}
+      <Dialog open={isPopupOpen} onOpenChange={setIsPopupOpen}>
+        <DialogContent className="sm:max-w-[420px] p-0 gap-0 flex flex-col max-h-[90dvh]">
+          <DialogHeader className="px-5 pt-5 pb-3 shrink-0">
+            <DialogTitle className="text-lg font-semibold">
+              {isMyProfile
+                ? "New Availability Slot"
+                : `${selectedDayName} Availability`}
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="flex-1 overflow-y-auto px-5 pb-3 space-y-3">
+            {isMyProfile && (
+              <>
+                {/* Session Type */}
+                <div>
+                  <Label className="text-xs text-muted-foreground mb-1.5 block">
+                    Session Type
+                  </Label>
+                  <div className="flex rounded-md border border-foreground/10 overflow-hidden">
+                    {(["1:1", "group"] as SessionType[]).map((t, i) => (
+                      <button
+                        key={t}
+                        type="button"
+                        onClick={() => setNewSession(t)}
+                        className={cn(
+                          "flex-1 flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-medium transition-colors",
+                          i > 0 && "border-l border-foreground/10",
+                          newSession === t
+                            ? "bg-primary text-primary-foreground"
+                            : "hover:bg-muted text-muted-foreground"
+                        )}
+                      >
+                        {t === "group" ? (
+                          <Users className="h-3.5 w-3.5" />
+                        ) : (
+                          <Video className="h-3.5 w-3.5" />
+                        )}
+                        {t === "1:1" ? "1-on-1" : "Group"}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Date */}
+                <div>
+                  <Label className="text-xs text-muted-foreground mb-1.5 block">
+                    Date
+                  </Label>
+                  <Input
+                    type="date"
+                    value={newDate}
+                    onChange={(e) => {
+                      setNewDate(e.target.value)
+                      if (e.target.value)
+                        setNewRepeatEnd(endOfMonth(e.target.value))
+                    }}
+                  />
+                </div>
+
+                {/* Start / End */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1.5 block">
+                      Start
+                    </Label>
+                    <Input
+                      type="time"
+                      value={newStart}
+                      onChange={(e) => {
+                        setNewStart(e.target.value)
+                        setSlotError("")
+                      }}
+                      className={cn(slotError && "border-destructive")}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1.5 block">
+                      End
+                    </Label>
+                    <Input
+                      type="time"
+                      value={newEnd}
+                      onChange={(e) => {
+                        setNewEnd(e.target.value)
+                        setSlotError("")
+                      }}
+                      className={cn(slotError && "border-destructive")}
+                    />
+                  </div>
+                </div>
+
+                {slotError && (
+                  <p className="text-destructive text-xs">{slotError}</p>
+                )}
+
+                {/* Repeat */}
+                <div className="flex items-center justify-between rounded-lg border border-foreground/8 px-3 py-2.5">
+                  <div className="flex items-center gap-2.5 text-sm">
+                    <RefreshCw className="h-4 w-4 text-muted-foreground" />
+                    <span>Repeat</span>
+                  </div>
+                  <div className="flex rounded-md border border-foreground/10 overflow-hidden">
+                    {(["none", "daily", "weekly"] as RepeatType[]).map(
+                      (r, i) => (
+                        <button
+                          key={r}
+                          type="button"
+                          onClick={() => setNewRepeat(r)}
+                          className={toggleItemCls(
+                            newRepeat === r,
+                            i === 0,
+                            "px-2.5 py-1"
+                          )}
+                        >
+                          {r === "none"
+                            ? "None"
+                            : r === "daily"
+                              ? "Daily"
+                              : "Weekly"}
+                        </button>
+                      )
+                    )}
+                  </div>
+                </div>
+
+                {/* Day-of-week picker */}
+                {newRepeat === "weekly" && (
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1.5 block">
+                      Repeat on
+                    </Label>
+                    <div className="flex flex-wrap gap-1.5">
+                      {DAY_HEADERS.map((label, dow) => {
+                        const active = newRepeatDays.includes(dow)
+                        return (
+                          <button
+                            key={dow}
+                            type="button"
+                            onClick={() => {
+                              setSlotError("")
+                              setNewRepeatDays((prev) =>
+                                prev.includes(dow)
+                                  ? prev.filter((d) => d !== dow)
+                                  : [...prev, dow]
+                              )
+                            }}
+                            className={cn(
+                              "flex-1 min-w-[36px] py-1.5 text-[11px] font-semibold rounded-md border transition-colors",
+                              active
+                                ? "bg-primary text-primary-foreground border-primary"
+                                : "border-foreground/10 text-muted-foreground hover:bg-muted"
+                            )}
+                          >
+                            {label}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Repeat until */}
+                {newRepeat !== "none" && (
+                  <div>
+                    <Label className="text-xs text-muted-foreground mb-1.5 block">
+                      Repeat until{" "}
+                      <span className="opacity-60">(optional)</span>
+                    </Label>
+                    <Input
+                      type="date"
+                      value={newRepeatEnd}
+                      min={newDate}
+                      onChange={(e) => setNewRepeatEnd(e.target.value)}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+
+            {/* Slot list */}
+            {slotsForSelected.length > 0 && (
+              <div className="pt-1 space-y-1.5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {isMyProfile ? "Existing Slots" : "Available Times"}
+                  {slotsForSelected.length > 2 && (
+                    <span className="ml-1.5 normal-case font-normal opacity-60">
+                      ({slotsForSelected.length})
+                    </span>
+                  )}
+                </p>
+                <div className="space-y-1.5 max-h-[152px] overflow-y-auto pr-0.5">
+                  {slotsForSelected.map((slot) => (
+                    <div
+                      key={slot.id}
+                      className="flex items-center justify-between rounded-lg border border-foreground/8 px-3 py-2.5 text-sm"
+                    >
+                      <div className="flex items-center gap-2.5 min-w-0">
+                        {slot.session_type === "group" ? (
+                          <Users className="h-4 w-4 text-muted-foreground shrink-0" />
+                        ) : (
+                          <Video className="h-4 w-4 text-muted-foreground shrink-0" />
+                        )}
+                        <div className="min-w-0">
+                          <p className="truncate">
+                            {formatTime(slot.start_time)} –{" "}
+                            {formatTime(slot.end_time)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {repeatLabel(slot)}
+                          </p>
+                        </div>
+                        <span className="text-xs text-muted-foreground border border-foreground/10 rounded px-1.5 py-0.5 shrink-0">
+                          {slot.session_type === "group" ? "Group" : "1-on-1"}
+                        </span>
+                      </div>
+                      {isMyProfile && (
+                        <button
+                          onClick={() => handleRemoveSlot(slot.id)}
+                          className="h-6 w-6 flex items-center justify-center shrink-0 rounded text-destructive hover:bg-destructive/10 transition-colors ml-2"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {!isMyProfile && slotsForSelected.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No availability set for this day
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-foreground/8 shrink-0">
+            <button
+              onClick={() => setIsPopupOpen(false)}
+              className="px-4 py-2 text-sm font-medium hover:text-foreground text-muted-foreground transition-colors"
+            >
+              {isMyProfile ? "Cancel" : "Close"}
+            </button>
+            {isMyProfile && (
+              <Button
+                onClick={handleAddSlot}
+                loading={saving}
+                className="h-9 px-5 text-sm rounded-lg"
+              >
+                Add Slot
+              </Button>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/src/components/Dashboard/profile/ProfileScreen.tsx
+++ b/src/components/Dashboard/profile/ProfileScreen.tsx
@@ -41,12 +41,7 @@ import {
   CardTitle,
   CardContent
 } from "@/src/components/ui/card"
-import {
-  generateUrl,
-  getPagePath,
-  getUserRole,
-  isMentor
-} from "@/src/utils/helpers"
+import { generateUrl, getPagePath, getUserRole } from "@/src/utils/helpers"
 import { UpdateUserProfilePictureAction } from "@/src/server-actions/User/User"
 import { useServerAction } from "@/src/hooks/useServerAction"
 import Loader from "../../common/Loader/Loader"
@@ -505,7 +500,7 @@ export default function ProfileScreen({
               </Card>
             )}
             {/* Mentor Info — shown to owner always; to others only when both fields are filled */}
-            {isMentor(user) && isMyProfile && (
+            {!!getUserRole(user)?.includes("Mentor") && isMyProfile && (
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center justify-between">

--- a/src/components/Dashboard/profile/ProfileScreen.tsx
+++ b/src/components/Dashboard/profile/ProfileScreen.tsx
@@ -41,7 +41,12 @@ import {
   CardTitle,
   CardContent
 } from "@/src/components/ui/card"
-import { generateUrl, getPagePath, getUserRole } from "@/src/utils/helpers"
+import {
+  generateUrl,
+  getPagePath,
+  getUserRole,
+  isMentor
+} from "@/src/utils/helpers"
 import { UpdateUserProfilePictureAction } from "@/src/server-actions/User/User"
 import { useServerAction } from "@/src/hooks/useServerAction"
 import Loader from "../../common/Loader/Loader"
@@ -499,8 +504,8 @@ export default function ProfileScreen({
                 </CardContent>
               </Card>
             )}
-            {/* Mentor Info — only shown when mentor setup is complete */}
-            {profile?.is_mentor_active && (
+            {/* Mentor Info — shown to owner always; to others only when both fields are filled */}
+            {isMentor(user) && isMyProfile && (
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center justify-between">
@@ -561,7 +566,7 @@ export default function ProfileScreen({
                           Completed Sessions
                         </p>
                         <p className="text-sm font-medium">
-                          {profile.total_completed_sessions}
+                          {profile?.total_completed_sessions}
                         </p>
                       </div>
                     </div>

--- a/src/components/Dashboard/profile/ProfileScreen.tsx
+++ b/src/components/Dashboard/profile/ProfileScreen.tsx
@@ -5,6 +5,7 @@ import ProfileBio from "@/src/components/Dashboard/profile/profile-bio"
 import { Avatar, AvatarFallback, AvatarImage } from "@/src/components/ui/avatar"
 import {
   CalendarIcon,
+  CalendarDays,
   Plus,
   PencilIcon,
   GraduationCap,
@@ -17,7 +18,12 @@ import {
   Instagram,
   Globe,
   Share2,
-  CopyIcon
+  CopyIcon,
+  Briefcase,
+  Building2,
+  Video,
+  Target,
+  CheckCircle2
 } from "lucide-react"
 import {
   SelectCertificate,
@@ -51,6 +57,10 @@ import Image from "next/image"
 import { useAtomValue } from "jotai"
 import { userStore } from "@/src/store/user/userStore"
 import EditSocialLinksModal from "./user/SocialLinksModal"
+import EditMentorModal from "./EditMentorModal"
+import { GetMentorAvailabilityAction } from "@/src/server-actions/Mentor/MentorActions"
+import { toLocalDateStr } from "@/src/lib/utils"
+import Link from "next/link"
 import { SocialLinkItem } from "./user/SocialLinkItem"
 import UserProfileCard from "./UserProfileCard"
 import TrustEngineCard from "./trust-engine/TrustEngineCard"
@@ -99,6 +109,17 @@ export default function ProfileScreen({
   )
   const [coverImage, setCoverImage] = useState(user.cover_image)
   const [referralLink, setReferralLink] = useState("")
+  const [mentorSlots, setMentorSlots] = useState<
+    {
+      id: number
+      date: string
+      repeat_type: string
+      repeat_end_date: string | null
+    }[]
+  >([])
+  const [, , , getMentorAvailability] = useServerAction(
+    GetMentorAvailabilityAction
+  )
   const authUser = useAtomValue(userStore.AuthUser)
 
   const displayUser = isMyProfile && authUser ? authUser : user
@@ -124,6 +145,26 @@ export default function ProfileScreen({
       setIsMyProfile(authUser.unique_id === user.unique_id)
     }
   }, [authUser, user])
+
+  // Fetch mentor slots for both owner and viewer — used to derive availability status
+  useEffect(() => {
+    if (!profile?.is_mentor_active) return
+    const fetchSlots = async () => {
+      const res = await getMentorAvailability(user.unique_id)
+      if (res?.success && res.data) {
+        setMentorSlots(res.data.filter((s) => s.is_active))
+      }
+    }
+    fetchSlots()
+  }, [profile?.is_mentor_active, user.unique_id])
+
+  // A mentor is "available" if they have at least one slot that hasn't expired
+  const todayStr = toLocalDateStr(new Date())
+  const isAvailable = mentorSlots.some((s) => {
+    if (s.repeat_type === "none") return s.date >= todayStr
+    // daily / weekly: available unless repeat_end_date is in the past
+    return !s.repeat_end_date || s.repeat_end_date >= todayStr
+  })
 
   useEffect(() => {
     const GetUserRecommendations = async () => {
@@ -458,6 +499,108 @@ export default function ProfileScreen({
                 </CardContent>
               </Card>
             )}
+            {/* Mentor Info — only shown when mentor setup is complete */}
+            {profile?.is_mentor_active && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center justify-between">
+                    <span className="flex items-center gap-2">Mentorship</span>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          isAvailable
+                            ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                            : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                        }`}
+                      >
+                        {isAvailable ? "Available" : "No Availability Set"}
+                      </span>
+                      {isMyProfile && (
+                        <EditMentorModal
+                          user={user}
+                          profile={profile as SelectProfile}
+                          setProfile={setProfile}
+                        />
+                      )}
+                    </div>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {/* Professional Title — always shown */}
+                  <div className="flex items-center gap-3">
+                    <Briefcase className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-xs text-muted-foreground">
+                        Professional Title
+                      </p>
+                      <p className="text-sm font-medium break-words">
+                        {profile?.professional_title || "—"}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Company — always shown */}
+                  <div className="flex items-center gap-3">
+                    <Building2 className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-xs text-muted-foreground">
+                        Company / Organisation
+                      </p>
+                      <p className="text-sm font-medium break-words">
+                        {profile?.company || "—"}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Completed Sessions */}
+                  {(profile?.total_completed_sessions ?? 0) > 0 && (
+                    <div className="flex items-center gap-3">
+                      <CheckCircle2 className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                      <div>
+                        <p className="text-xs text-muted-foreground">
+                          Completed Sessions
+                        </p>
+                        <p className="text-sm font-medium">
+                          {profile.total_completed_sessions}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Mentor: manage their own availability */}
+                  {isMyProfile && (
+                    <Link href="/profile/availability" className="w-full">
+                      <Button
+                        variant="outline"
+                        className="w-full mt-2"
+                        size="sm"
+                      >
+                        <CalendarDays className="h-4 w-4 mr-2" />
+                        Manage Availability
+                      </Button>
+                    </Link>
+                  )}
+
+                  {/* Viewer: see mentor's availability when slots exist */}
+                  {!isMyProfile && mentorSlots.length > 0 && (
+                    <Link
+                      href={`/profile/${user.unique_id}/availability`}
+                      className="w-full"
+                    >
+                      <Button
+                        variant="outline"
+                        className="w-full mt-2"
+                        size="sm"
+                      >
+                        <CalendarDays className="h-4 w-4 mr-2" />
+                        View Availability
+                      </Button>
+                    </Link>
+                  )}
+                </CardContent>
+              </Card>
+            )}
+
             {/* Education */}
             <Card>
               <CardHeader>

--- a/src/components/Dashboard/profile/types/profile-types.ts
+++ b/src/components/Dashboard/profile/types/profile-types.ts
@@ -26,6 +26,8 @@ export type ProfileData = {
   bio: string
   skills: number[]
   interests: number[]
+  professional_title?: string
+  company?: string
 }
 
 export type Profile = {

--- a/src/components/ProfileCompletion/ProfileCompletionForm.tsx
+++ b/src/components/ProfileCompletion/ProfileCompletionForm.tsx
@@ -14,17 +14,17 @@ import { StepThree } from "./StepThree"
 import { OnboardingCompletion } from "../TrustEngine/OnboardingCompletion"
 import { DynamicIcon, IconName } from "lucide-react/dynamic"
 import { SelectUser } from "@/src/db/schema"
+import { getUserRole } from "@/src/utils/helpers"
 import { AuthUserAction } from "@/src/server-actions/User/AuthUserAction"
 import { getFeatureFlagAction } from "@/src/server-actions/FeatureFlag/FeatureFlag"
 import { useRouter } from "next/navigation"
-import { isMentor } from "@/src/utils/helpers"
 
 export default function ProfileCompletionForm() {
   const [step, setStep] = useState(1)
   const [user, setUser] = useState<SelectUser>()
   const [isTrustEngineEnabled, setIsTrustEngineEnabled] = useState(false)
 
-  const userIsMentor = isMentor(user)
+  const userIsMentor = !!getUserRole(user!)?.includes("Mentor")
   const totalSteps = 4
 
   useEffect(() => {

--- a/src/components/ProfileCompletion/ProfileCompletionForm.tsx
+++ b/src/components/ProfileCompletion/ProfileCompletionForm.tsx
@@ -17,11 +17,15 @@ import { SelectUser } from "@/src/db/schema"
 import { AuthUserAction } from "@/src/server-actions/User/AuthUserAction"
 import { getFeatureFlagAction } from "@/src/server-actions/FeatureFlag/FeatureFlag"
 import { useRouter } from "next/navigation"
+import { isMentor } from "@/src/utils/helpers"
 
 export default function ProfileCompletionForm() {
   const [step, setStep] = useState(1)
   const [user, setUser] = useState<SelectUser>()
   const [isTrustEngineEnabled, setIsTrustEngineEnabled] = useState(false)
+
+  const userIsMentor = isMentor(user)
+  const totalSteps = 4
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -45,32 +49,21 @@ export default function ProfileCompletionForm() {
   }, [])
 
   const steps = [
-    {
-      title: "Personal Info",
-      icon: "user"
-    },
-    {
-      title: "Education",
-      icon: "graduation-cap"
-    },
-    {
-      title: "Social Links",
-      icon: "link-2"
-    },
-    {
-      title: "Complete",
-      icon: "check-circle"
-    }
+    { title: "Personal Info", icon: "user" },
+    { title: "Education", icon: "graduation-cap" },
+    { title: "Social Links", icon: "link-2" },
+    { title: "Complete", icon: "check-circle" }
   ]
-  const progress = ((step - 1) / 3) * 100
+
+  const progress = ((step - 1) / (totalSteps - 1)) * 100
 
   const router = useRouter()
 
   useEffect(() => {
-    if (step === 4 && !isTrustEngineEnabled) {
+    if (step === totalSteps && !isTrustEngineEnabled) {
       router.push("/profile")
     }
-  }, [step, isTrustEngineEnabled, router])
+  }, [step, totalSteps, isTrustEngineEnabled, router])
 
   return (
     <Card className="w-full">
@@ -112,6 +105,7 @@ export default function ProfileCompletionForm() {
             setStep={setStep}
             user={user}
             setUser={setUser}
+            isMentor={userIsMentor}
           />
         )}
         {step === 2 && user && (
@@ -128,9 +122,13 @@ export default function ProfileCompletionForm() {
             setStep={setStep}
             user={user}
             setUser={setUser}
+            totalSteps={totalSteps}
+            isMentor={userIsMentor}
           />
         )}
-        {step === 4 && isTrustEngineEnabled && (
+
+        {/* Completion step */}
+        {step === totalSteps && isTrustEngineEnabled && (
           <OnboardingCompletion
             redirectTo="/profile"
             buttonLabel="Go to Profile"

--- a/src/components/ProfileCompletion/StepOne.tsx
+++ b/src/components/ProfileCompletion/StepOne.tsx
@@ -36,21 +36,22 @@ interface StepOneProps {
   setStep: Dispatch<SetStateAction<number>>
   user: SelectUser
   setUser: Dispatch<SetStateAction<SelectUser | undefined>>
+  isMentor?: boolean
 }
 
-const profileSchema = z.object({
+const baseProfileSchema = z.object({
   first_name: z
     .string()
     .min(1, "First Name Required")
-    .max(30, "Maximum 30 characters allowed"),
+    .max(30, "Maximum 30 characters allowed"),
   last_name: z
     .string()
     .min(1, "Last Name Required")
-    .max(30, "Maximum 30 characters allowed"),
+    .max(30, "Maximum 30 characters allowed"),
   bio: z
     .string()
     .min(1, "Bio Required")
-    .max(2000, "Maximum 2000 characters allowed"),
+    .max(2000, "Maximum 2000 characters allowed"),
   skill: z
     .array(z.string().min(1, "required"))
     .min(1, "At least one skill is required"),
@@ -59,7 +60,25 @@ const profileSchema = z.object({
     .min(1, "At least one interest is required")
 })
 
-export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
+// Mentors also supply professional title + company on this step
+const mentorProfileSchema = baseProfileSchema.extend({
+  professional_title: z
+    .string()
+    .min(1, "Title is required")
+    .max(100, "Maximum 100 characters"),
+  company: z
+    .string()
+    .min(1, "Company is required")
+    .max(100, "Maximum 100 characters")
+})
+
+export function StepOne({
+  step,
+  setStep,
+  user,
+  setUser,
+  isMentor = false
+}: StepOneProps) {
   const { toast } = useToast()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { user: clerkUser } = useUser()
@@ -70,7 +89,7 @@ export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
   const [selectedInterestTags, setSelectedInterestTags] = useState<
     MultiSelectOption[]
   >([])
-  const [currentImageUrl, setCurrentImageUrl] = useState(user?.profile_url) // State to manage current profile image URL
+  const [currentImageUrl, setCurrentImageUrl] = useState(user?.profile_url)
   const [isTransitioning, setIsTransitioning] = useState(false)
 
   const [
@@ -84,17 +103,20 @@ export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
     UpdateUserProfilePictureAction
   )
 
-  type ProfileFormValues = z.infer<typeof profileSchema>
+  const schema = isMentor ? mentorProfileSchema : baseProfileSchema
+  type ProfileFormValues = z.infer<typeof schema>
 
   const form = useForm<ProfileFormValues>({
-    resolver: zodResolver(profileSchema),
+    resolver: zodResolver(schema),
     defaultValues: {
       first_name: "",
       last_name: "",
       bio: "",
       skill: [],
-      interest: []
-    }
+      interest: [],
+      professional_title: "",
+      company: ""
+    } as any
   })
 
   const formError = form.formState.errors
@@ -109,6 +131,12 @@ export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
   useEffect(() => {
     if (user.profile?.bio) {
       form.setValue("bio", user.profile?.bio)
+    }
+    if (isMentor && user.profile) {
+      const profile = user.profile as any
+      if (profile.professional_title)
+        form.setValue("professional_title" as any, profile.professional_title)
+      if (profile.company) form.setValue("company" as any, profile.company)
     }
   }, [user.profile?.bio])
 
@@ -169,7 +197,11 @@ export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
         last_name: data.last_name,
         bio: data.bio,
         skills: data.skill,
-        interests: data.interest
+        interests: data.interest,
+        ...(isMentor && {
+          professional_title: data.professional_title,
+          company: data.company
+        })
       }
       const res = await updateProfile(payload)
       await clerkUser?.reload()
@@ -423,6 +455,62 @@ export function StepOne({ step, setStep, user, setUser }: StepOneProps) {
               </span>
             )}
           </div>
+
+          {/* Professional Title + Company — shown for mentors only */}
+          {isMentor && (
+            <div className="mt-4 pt-4 border-t space-y-4">
+              <div>
+                <h4 className="text-sm font-semibold">Mentor Details</h4>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Shown on your public mentor profile
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="professional_title" className="font-semibold">
+                    Professional Title
+                  </Label>
+                  <Controller
+                    name={"professional_title" as any}
+                    control={form.control}
+                    render={({ field }) => (
+                      <Input
+                        id="professional_title"
+                        placeholder="e.g. Senior Engineer"
+                        {...field}
+                      />
+                    )}
+                  />
+                  {(formError as any).professional_title && (
+                    <span className="text-red-500 text-xs">
+                      {String((formError as any).professional_title.message)}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor="company" className="font-semibold">
+                    Company / Organisation
+                  </Label>
+                  <Controller
+                    name={"company" as any}
+                    control={form.control}
+                    render={({ field }) => (
+                      <Input
+                        id="company"
+                        placeholder="e.g. Google"
+                        {...field}
+                      />
+                    )}
+                  />
+                  {(formError as any).company && (
+                    <span className="text-red-500 text-xs">
+                      {String((formError as any).company.message)}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
 
           {step < 4 && (
             <div className="flex justify-between pt-6 border-t mt-4">

--- a/src/components/ProfileCompletion/StepThree.tsx
+++ b/src/components/ProfileCompletion/StepThree.tsx
@@ -64,8 +64,7 @@ export function StepThree({
 
       const finalData = {
         ...socialPlatforms,
-        is_profile_completed: 1,
-        ...(isMentor && { is_mentor_active: true })
+        is_profile_completed: 1
       }
 
       const res = await submitUserProfileData(

--- a/src/components/ProfileCompletion/StepThree.tsx
+++ b/src/components/ProfileCompletion/StepThree.tsx
@@ -22,9 +22,18 @@ interface StepThreeProps {
   setStep: Dispatch<SetStateAction<number>>
   user: SelectUser
   setUser: Dispatch<SetStateAction<SelectUser | undefined>>
+  totalSteps?: number
+  isMentor?: boolean
 }
 
-export function StepThree({ step, setStep, user, setUser }: StepThreeProps) {
+export function StepThree({
+  step,
+  setStep,
+  user,
+  setUser,
+  totalSteps = 4,
+  isMentor = false
+}: StepThreeProps) {
   const [submitDataLoading, , , submitUserProfileData] = useServerAction(
     userProfileCompletionAction
   )
@@ -55,7 +64,8 @@ export function StepThree({ step, setStep, user, setUser }: StepThreeProps) {
 
       const finalData = {
         ...socialPlatforms,
-        is_profile_completed: 1
+        is_profile_completed: 1,
+        ...(isMentor && { is_mentor_active: true })
       }
 
       const res = await submitUserProfileData(
@@ -74,7 +84,7 @@ export function StepThree({ step, setStep, user, setUser }: StepThreeProps) {
         })
 
         if (!submitDataLoading) {
-          setStep(4) // Go to completion step
+          setStep((prev) => prev + 1)
         }
       } else {
         setIsTransitioning(false)
@@ -133,7 +143,7 @@ export function StepThree({ step, setStep, user, setUser }: StepThreeProps) {
               </Card>
             )
           })}
-          {step < 4 && (
+          {step < totalSteps && (
             <div className="flex justify-between pt-6 border-t">
               <Button
                 variant="outline"

--- a/src/db/migrations/0045_2026_07_02_200207__add_table_and_add_column_in_users_table.sql
+++ b/src/db/migrations/0045_2026_07_02_200207__add_table_and_add_column_in_users_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "mentor_availability" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "mentor_availability_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"mentor_id" varchar NOT NULL,
+	"date" varchar NOT NULL,
+	"start_time" varchar NOT NULL,
+	"end_time" varchar NOT NULL,
+	"session_type" varchar DEFAULT '1:1' NOT NULL,
+	"repeat_type" varchar DEFAULT 'none' NOT NULL,
+	"repeat_end_date" varchar,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"updated_at" varchar,
+	"created_at" varchar DEFAULT CURRENT_TIMESTAMP,
+	"deleted_at" varchar
+);
+--> statement-breakpoint
+ALTER TABLE "profile" ADD COLUMN "professional_title" varchar;--> statement-breakpoint
+ALTER TABLE "profile" ADD COLUMN "company" varchar;--> statement-breakpoint
+ALTER TABLE "profile" ADD COLUMN "is_mentor_active" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "profile" ADD COLUMN "total_completed_sessions" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "mentor_availability" ADD CONSTRAINT "mentor_availability_mentor_id_users_unique_id_fk" FOREIGN KEY ("mentor_id") REFERENCES "public"."users"("unique_id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/src/db/migrations/meta/2026_07_02_200207__add_table_and_add_column_in_users_table_snapshot.json
+++ b/src/db/migrations/meta/2026_07_02_200207__add_table_and_add_column_in_users_table_snapshot.json
@@ -1,0 +1,5094 @@
+{
+  "id": "5d5d7d70-8e5b-4ba4-8e41-da1697742516",
+  "prevId": "724b9b54-f6cc-40c8-b415-f8b546c7d690",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.channel_users": {
+      "name": "channel_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "channel_users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_user_id": {
+          "name": "community_user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_users_community_user_id_community_users_id_fk": {
+          "name": "channel_users_community_user_id_community_users_id_fk",
+          "tableFrom": "channel_users",
+          "tableTo": "community_users",
+          "columnsFrom": ["community_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_users": {
+      "name": "project_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_chats": {
+      "name": "space_chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "space_chats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_users": {
+      "name": "space_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "space_users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_users_channel_user_id_channel_users_id_fk": {
+          "name": "space_users_channel_user_id_channel_users_id_fk",
+          "tableFrom": "space_users",
+          "tableTo": "channel_users",
+          "columnsFrom": ["channel_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sprints": {
+      "name": "sprints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sprint_status": {
+          "name": "sprint_status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks_status": {
+      "name": "tasks_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_slug": {
+          "name": "status_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defination_of_completion": {
+          "name": "defination_of_completion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activities": {
+      "name": "activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "activities_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_rules": {
+      "name": "activity_rules",
+      "schema": "",
+      "columns": {
+        "rule_id": {
+          "name": "rule_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_display_name": {
+          "name": "action_display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_points": {
+          "name": "base_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_group": {
+          "name": "category_group",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_verification": {
+          "name": "required_verification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificates": {
+      "name": "certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "certificates_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institute": {
+          "name": "institute",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "certificates_user_id_users_unique_id_fk": {
+          "name": "certificates_user_id_users_unique_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_slug": {
+          "name": "channel_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_channel": {
+          "name": "publish_channel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channels_community_id_communities_id_fk": {
+          "name": "channels_community_id_communities_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "chats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_slug": {
+          "name": "chat_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_index": {
+          "name": "name_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_message": {
+          "name": "last_message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "comments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communities": {
+      "name": "communities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "communities_slug_unique": {
+          "name": "communities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_categories": {
+      "name": "community_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_categories_slug_unique": {
+          "name": "community_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_requests": {
+      "name": "community_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "university_name": {
+          "name": "university_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "official_university_email": {
+          "name": "official_university_email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person_id": {
+          "name": "contact_person_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_person_name": {
+          "name": "contact_person_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_number": {
+          "name": "contact_number",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designation": {
+          "name": "designation",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_website": {
+          "name": "university_website",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_number_of_students": {
+          "name": "estimated_number_of_students",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intended_usage": {
+          "name": "intended_usage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invite_link": {
+          "name": "invite_link",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_users": {
+      "name": "community_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_users_community_id_communities_id_fk": {
+          "name": "community_users_community_id_communities_id_fk",
+          "tableFrom": "community_users",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_users_user_id_users_unique_id_fk": {
+          "name": "community_users_user_id_users_unique_id_fk",
+          "tableFrom": "community_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_us": {
+      "name": "contact_us",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "contact_us_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "unique_id": {
+          "name": "unique_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_templates_name_unique": {
+          "name": "email_templates_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_users": {
+      "name": "event_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_users_event_id_events_id_fk": {
+          "name": "event_users_event_id_events_id_fk",
+          "tableFrom": "event_users",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_users_user_id_users_unique_id_fk": {
+          "name": "event_users_user_id_users_unique_id_fk",
+          "tableFrom": "event_users",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImage": {
+          "name": "coverImage",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date_time": {
+          "name": "start_date_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date_time": {
+          "name": "end_date_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_host_id_users_unique_id_fk": {
+          "name": "events_host_id_users_unique_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": ["host_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feature_flags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_key_unique": {
+          "name": "feature_flags_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.features": {
+      "name": "features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "features_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "feature_name": {
+          "name": "feature_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_slug": {
+          "name": "feature_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_description": {
+          "name": "feature_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_icon": {
+          "name": "feature_icon",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_url": {
+          "name": "feature_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_order": {
+          "name": "feature_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "feature_status": {
+          "name": "feature_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "feedbacks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invite_email": {
+          "name": "invite_email",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "joined_email": {
+          "name": "joined_email",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_offer_id": {
+          "name": "role_offer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_invited_by_users_unique_id_fk": {
+          "name": "invitations_invited_by_users_unique_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_role_offer_id_roles_id_fk": {
+          "name": "invitations_role_offer_id_roles_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "roles",
+          "columnsFrom": ["role_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_key_unique": {
+          "name": "invitations_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaderboard_snapshots": {
+      "name": "leaderboard_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "leaderboard_snapshots_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "points_gained": {
+          "name": "points_gained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trend": {
+          "name": "trend",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'neutral'"
+        },
+        "rank_change": {
+          "name": "rank_change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_datetime": {
+          "name": "snapshot_datetime",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leaderboard_snapshots_community_id_communities_id_fk": {
+          "name": "leaderboard_snapshots_community_id_communities_id_fk",
+          "tableFrom": "leaderboard_snapshots",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leaderboard_snapshots_user_id_users_unique_id_fk": {
+          "name": "leaderboard_snapshots_user_id_users_unique_id_fk",
+          "tableFrom": "leaderboard_snapshots",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mentor_availability": {
+      "name": "mentor_availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "mentor_availability_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1:1'"
+        },
+        "repeat_type": {
+          "name": "repeat_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "repeat_end_date": {
+          "name": "repeat_end_date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mentor_availability_mentor_id_users_unique_id_fk": {
+          "name": "mentor_availability_mentor_id_users_unique_id_fk",
+          "tableFrom": "mentor_availability",
+          "tableTo": "users",
+          "columnsFrom": ["mentor_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notifications_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "permissions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_ledger": {
+      "name": "point_ledger",
+      "schema": "",
+      "columns": {
+        "transection_id": {
+          "name": "transection_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "point_ledger_transection_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_ref_id": {
+          "name": "external_ref_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trust_verification_id": {
+          "name": "trust_verification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transection_type": {
+          "name": "transection_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "poll_options_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_files": {
+      "name": "post_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "post_files_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_hashtags": {
+      "name": "post_hashtags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "post_hashtags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashtag_id": {
+          "name": "hashtag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "profile_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "degree": {
+          "name": "degree",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "institute": {
+          "name": "institute",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_start_date": {
+          "name": "education_start_date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "education_end_date": {
+          "name": "education_end_date",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin_url": {
+          "name": "linkedin_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_url": {
+          "name": "instagram_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter_url": {
+          "name": "twitter_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_website_url": {
+          "name": "personal_website_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sum_of_ratings": {
+          "name": "sum_of_ratings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "number_of_ratings": {
+          "name": "number_of_ratings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_average_rating": {
+          "name": "total_average_rating",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_profile_completed": {
+          "name": "is_profile_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "professional_title": {
+          "name": "professional_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_mentor_active": {
+          "name": "is_mentor_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_completed_sessions": {
+          "name": "total_completed_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_user_id_users_unique_id_fk": {
+          "name": "profile_user_id_users_unique_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["unique_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_recent_activity": {
+      "name": "project_recent_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "project_recent_activity_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity": {
+          "name": "activity",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deep_link": {
+          "name": "deep_link",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_slug": {
+          "name": "project_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_startDate": {
+          "name": "project_startDate",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_targetDate": {
+          "name": "project_targetDate",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_space_id_spaces_id_fk": {
+          "name": "project_space_id_spaces_id_fk",
+          "tableFrom": "project",
+          "tableTo": "spaces",
+          "columnsFrom": ["space_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations": {
+      "name": "recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "recommendations_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommender_id": {
+          "name": "recommender_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiver_id": {
+          "name": "receiver_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_level": {
+      "name": "reward_level",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_points": {
+          "name": "min_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_points": {
+          "name": "max_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_metadata": {
+      "name": "rewards_metadata",
+      "schema": "",
+      "columns": {
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "internal_name": {
+          "name": "internal_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_soulbound": {
+          "name": "is_soulbound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "has_decay": {
+          "name": "has_decay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "decay_period": {
+          "name": "decay_period",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "rewards_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "badge_type": {
+          "name": "badge_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "roles_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shortcuts": {
+      "name": "shortcuts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_id": {
+          "name": "community_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelid": {
+          "name": "channelid",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shortcuts_community_id_communities_id_fk": {
+          "name": "shortcuts_community_id_communities_id_fk",
+          "tableFrom": "shortcuts",
+          "tableTo": "communities",
+          "columnsFrom": ["community_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shortcuts_channelid_channels_channel_id_fk": {
+          "name": "shortcuts_channelid_channels_channel_id_fk",
+          "tableFrom": "shortcuts",
+          "tableTo": "channels",
+          "columnsFrom": ["channelid"],
+          "columnsTo": ["channel_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shortcuts_space_id_spaces_id_fk": {
+          "name": "shortcuts_space_id_spaces_id_fk",
+          "tableFrom": "shortcuts",
+          "tableTo": "spaces",
+          "columnsFrom": ["space_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "shortcuts_project_id_project_id_fk": {
+          "name": "shortcuts_project_id_project_id_fk",
+          "tableFrom": "shortcuts",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "site_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page": {
+          "name": "page",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_features": {
+      "name": "space_features",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "space_features_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.space_file_directory": {
+      "name": "space_file_directory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "space_file_directory_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug": {
+          "name": "entity_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_size": {
+          "name": "entity_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_slug": {
+          "name": "space_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_name": {
+          "name": "space_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_type": {
+          "name": "space_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_space": {
+          "name": "publish_space",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overview": {
+          "name": "overview",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_channel_id_channels_channel_id_fk": {
+          "name": "spaces_channel_id_channels_channel_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["channel_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sprint_burndown": {
+      "name": "sprint_burndown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sprint_burndown_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "sprint_id": {
+          "name": "sprint_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tasks": {
+          "name": "total_tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completed_tasks": {
+          "name": "completed_tasks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_story_points": {
+          "name": "total_story_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.successful_referrals": {
+      "name": "successful_referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "successful_referrals_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "referrer_user_id": {
+          "name": "referrer_user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referred_user_id": {
+          "name": "referred_user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "task_comments_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_history": {
+          "name": "task_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task": {
+      "name": "task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_num": {
+          "name": "task_num",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_title": {
+          "name": "task_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_priority": {
+          "name": "task_priority",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "story_points": {
+          "name": "story_points",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_id": {
+          "name": "status_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sprint_id": {
+          "name": "sprint_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assign_to": {
+          "name": "assign_to",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assign_by": {
+          "name": "assign_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_task_id": {
+          "name": "parent_task_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tested_by": {
+          "name": "tested_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trust_verification": {
+      "name": "trust_verification",
+      "schema": "",
+      "columns": {
+        "verification_id": {
+          "name": "verification_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "trust_verification_verification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_url": {
+          "name": "proof_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_activities_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_chats": {
+      "name": "user_chats",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unread_count": {
+          "name": "unread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_contacts": {
+      "name": "user_contacts",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_requested": {
+          "name": "is_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_accepted": {
+          "name": "is_accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_blocked": {
+          "name": "is_blocked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_following": {
+          "name": "is_following",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_followed_by": {
+          "name": "is_followed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_messages": {
+      "name": "user_messages",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_reward_balance": {
+      "name": "user_reward_balance",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rewards_level": {
+      "name": "user_rewards_level",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_rewards_level_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_id": {
+          "name": "level_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rewards": {
+      "name": "user_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_rewards_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reward_id": {
+          "name": "reward_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tags": {
+      "name": "user_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_tags_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "unique_id": {
+          "name": "unique_id",
+          "type": "varchar(36)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_auth_id": {
+          "name": "external_auth_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "meta_profile": {
+          "name": "meta_profile",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"bio_written\":false,\"persona_selected\":false,\"profile_picture_uploaded\":false}'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_external_auth_id_unique": {
+          "name": "users_external_auth_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["external_auth_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1779116292296,
       "tag": "0044_2026_05_18_195808__create_contact_us_table",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1782993728647,
+      "tag": "0045_2026_07_02_200207__add_table_and_add_column_in_users_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -176,6 +176,13 @@ export const profileTable = pgTable("profile", {
   number_of_ratings: integer().default(0),
   total_average_rating: varchar().default("0"),
   is_profile_completed: integer().notNull().default(0),
+
+  professional_title: varchar("professional_title"),
+  company: varchar("company"),
+  is_mentor_active: boolean("is_mentor_active").notNull().default(false),
+  total_completed_sessions: integer("total_completed_sessions")
+    .notNull()
+    .default(0),
   ...timestamps
 })
 
@@ -191,6 +198,26 @@ export type InsertProfile = typeof profileTable.$inferInsert
 export type SelectProfile = typeof profileTable.$inferSelect & {
   user?: SelectUser
 }
+
+export const mentorAvailabilityTable = pgTable("mentor_availability", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  mentor_id: varchar("mentor_id")
+    .notNull()
+    .references(() => usersTable.unique_id, { onDelete: "cascade" }),
+  date: varchar("date").notNull(), // YYYY-MM-DD  (the anchor / start date)
+  start_time: varchar("start_time").notNull(),
+  end_time: varchar("end_time").notNull(),
+  session_type: varchar("session_type").notNull().default("1:1"),
+  repeat_type: varchar("repeat_type").notNull().default("none"), // "none" | "daily" | "weekly"
+  repeat_end_date: varchar("repeat_end_date"), // YYYY-MM-DD, nullable
+  is_active: boolean("is_active").notNull().default(true),
+  ...timestamps
+})
+
+export type InsertMentorAvailability =
+  typeof mentorAvailabilityTable.$inferInsert
+export type SelectMentorAvailability =
+  typeof mentorAvailabilityTable.$inferSelect
 
 export const certificatesTable = pgTable("certificates", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+/** Format a Date as YYYY-MM-DD using local time (not UTC). */
+export function toLocalDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`
+}

--- a/src/server-actions/Mentor/MentorActions.ts
+++ b/src/server-actions/Mentor/MentorActions.ts
@@ -1,0 +1,104 @@
+"use server"
+
+import { CreateServerAction } from ".."
+import { db } from "@/src/db"
+import { mentorAvailabilityTable } from "@/src/db/schema"
+import { eq } from "drizzle-orm"
+import { AuthUserAction } from "../User/AuthUserAction"
+import { updateUserProfile } from "@/src/db/data-access/profile/query"
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface SaveMentorSetupPayload {
+  userId: string
+  professional_title: string
+  company: string
+}
+
+interface AvailabilitySlot {
+  date: string // YYYY-MM-DD (anchor / start date)
+  start_time: string
+  end_time: string
+  session_type: string
+  repeat_type: string // "none" | "daily" | "weekly"
+  repeat_end_date?: string | null
+}
+
+// ── Actions ────────────────────────────────────────────────────────────────────
+
+/** Save mentor professional_title and company. */
+export const SaveMentorSetupAction = CreateServerAction(
+  true,
+  async (payload: SaveMentorSetupPayload) => {
+    try {
+      await updateUserProfile(payload.userId, {
+        professional_title: payload.professional_title,
+        company: payload.company
+      })
+      return { success: true }
+    } catch (error) {
+      console.error("SaveMentorSetupAction error:", error)
+      return { error: "Failed to save mentor setup" }
+    }
+  }
+)
+
+/** Fetch all availability slots for a mentor. */
+export const GetMentorAvailabilityAction = CreateServerAction(
+  true,
+  async (mentorId: string) => {
+    try {
+      const slots = await db
+        .select()
+        .from(mentorAvailabilityTable)
+        .where(eq(mentorAvailabilityTable.mentor_id, mentorId))
+
+      return { success: true, data: slots }
+    } catch (error) {
+      console.error("GetMentorAvailabilityAction error:", error)
+      return { error: "Failed to fetch availability" }
+    }
+  }
+)
+
+/** Replace all slots for a mentor atomically (delete + reinsert in one transaction). */
+export const UpdateAvailabilityAction = CreateServerAction(
+  true,
+  async (payload: { mentorId: string; slots: AvailabilitySlot[] }) => {
+    try {
+      const { mentorId, slots } = payload
+
+      // Auth guard — only the mentor themselves can update their slots
+      const authUser = await AuthUserAction()
+      if (!authUser || authUser.unique_id !== mentorId) {
+        return { error: "Unauthorised" }
+      }
+
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(mentorAvailabilityTable)
+          .where(eq(mentorAvailabilityTable.mentor_id, mentorId))
+
+        if (slots.length > 0) {
+          await tx.insert(mentorAvailabilityTable).values(
+            slots.map((slot) => ({
+              mentor_id: mentorId,
+              date: slot.date,
+              start_time: slot.start_time,
+              end_time: slot.end_time,
+              session_type: slot.session_type,
+              repeat_type: slot.repeat_type,
+              repeat_end_date: slot.repeat_end_date ?? null,
+              is_active: true
+            }))
+          )
+        }
+      })
+
+      return { success: true }
+    } catch (error) {
+      console.error("UpdateAvailabilityAction error:", error)
+      return { error: "Failed to update availability" }
+    }
+  }
+)

--- a/src/server-actions/User/User.ts
+++ b/src/server-actions/User/User.ts
@@ -50,13 +50,20 @@ export const SaveUserProfileAction = CreateServerAction(
         })
       }
 
-      // Check if user profile already exist the update it otherwise create new profile
+      // Build profile update payload — always includes bio; mentor fields when present
+      const profileUpdate: Record<string, any> = { bio: profileData.bio }
+      if (profileData.professional_title !== undefined)
+        profileUpdate.professional_title = profileData.professional_title
+      if (profileData.company !== undefined)
+        profileUpdate.company = profileData.company
+
+      // Check if user profile already exists; update it otherwise create new profile
       if (userProfile) {
-        await updateUserProfile(profileData.userId, { bio: profileData.bio })
+        await updateUserProfile(profileData.userId, profileUpdate)
       } else {
         await createUserProfile({
           user_id: profileData.userId,
-          bio: profileData.bio
+          ...profileUpdate
         })
       }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -333,3 +333,30 @@ export const trustEngineFeatures = [
 ]
 
 export const EntityUpdateBroadCast = "broadcast-entity-update"
+
+export const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+]
+
+export const DAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday"
+]
+
+export const DAY_HEADERS = DAYS.map((d) => d.slice(0, 3))

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -303,21 +303,6 @@ export function serializeUserPerms(userPerms: {
   }
 }
 
-/** Returns true if the user has a role with the given name. */
-export function hasRole(
-  user: SelectUser | null | undefined,
-  roleName: string
-): boolean {
-  return (
-    user?.roles?.some((r: SelectUserRole) => r.role?.name === roleName) ?? false
-  )
-}
-
-/** Convenience wrapper — true if the user has the "Mentor" role. */
-export function isMentor(user: SelectUser | null | undefined): boolean {
-  return hasRole(user, "Mentor")
-}
-
 export async function isSuperAdmin(user: SelectUser): Promise<boolean> {
   try {
     if (!user.roles || user.roles.length === 0) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -329,7 +329,11 @@ export const formatRelativeTime = (
     .fromNow()
 }
 
-export const getUserRole = (user: SelectUser, entity_id?: string) => {
+export const getUserRole = (
+  user: SelectUser | null | undefined,
+  entity_id?: string
+) => {
+  if (!user) return undefined
   if (user.roles && user.roles.length > 0) {
     if (user.roles.some((ur) => ur.role?.role_type === "SYSTEM")) {
       return user.roles.flatMap((ur) =>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -303,6 +303,21 @@ export function serializeUserPerms(userPerms: {
   }
 }
 
+/** Returns true if the user has a role with the given name. */
+export function hasRole(
+  user: SelectUser | null | undefined,
+  roleName: string
+): boolean {
+  return (
+    user?.roles?.some((r: SelectUserRole) => r.role?.name === roleName) ?? false
+  )
+}
+
+/** Convenience wrapper — true if the user has the "Mentor" role. */
+export function isMentor(user: SelectUser | null | undefined): boolean {
+  return hasRole(user, "Mentor")
+}
+
 export async function isSuperAdmin(user: SelectUser): Promise<boolean> {
   try {
     if (!user.roles || user.roles.length === 0) {


### PR DESCRIPTION
feat: Mentor availability management

## What
Full mentor availability system — mentors can set recurring time slots, viewers can browse a mentor's calendar, and profile cards derive live availability status from actual slot data.

## Changes

**Schema**
- Added `mentor_availability` table (mentor_id, date, start_time, end_time, session_type, repeat_type, repeat_end_date, is_active)
- Removed unused columns from `profile` table: session_type, engagement_type, availability_status

**New components / pages**
- MentorCalendar — full-page calendar (month + week view), slot creation popup with session type toggle, repeat options (none / daily / weekly with day-of-week multi-select), overlap validation, scrollable slot list
- AvailabilityPageShell — shared page chrome for both availability routes
- /profile/availability — mentor manages own slots
- /profile/[id]/availability — viewer sees mentor's calendar (read-only)

**Profile card**
- Shows Professional Title and Company (replaced Session Type / Focus Area)
- Availability badge (Available / No Availability Set) derived at runtime from slot data — no static field
- Fixed onboarding not persisting professional_title and company on first profile creation

**Server actions**
- Consolidated GetMentorAvailabilityAction, SaveMentorSetupAction, UpdateAvailabilityAction into a single MentorActions.ts
- UpdateAvailabilityAction uses a DB transaction (delete + reinsert) with an auth guard

**Utilities**
- toLocalDateStr(date) added to src/lib/utils.ts — local-time YYYY-MM-DD formatting
- hasRole(user, roleName) + isMentor(user) added to src/utils/helpers.ts

**Cleanup**
- Removed session_type / engagement_type from EditMentorModal
- Stubbed dead files: ManageAvailabilityModal, ViewAvailabilityModal, StepMentor, MentorSetupFields

## Notes
- Run `npm run db:migrate` to sync schema changes
- No new external dependencies — calendar is custom Tailwind, no library