### PR TITLE
Feature/sw 400 feedback overview

### DIFF
--- a/src/services/notifications/Mentor/utils.ts
+++ b/src/services/notifications/Mentor/utils.ts
@@ -18,7 +18,9 @@ export const SendMentorSlotSuggestionNotification = async (
       template: {
         title: `${mentorName} suggested new slots`,
         body: `${mentorName} suggested new session slots for "${request.topic}". Please review and respond.`,
-        deep_link: createAbsoluteUrl(`/mentors`),
+        deep_link: createAbsoluteUrl(
+          `/profile/${request.mentor_id}/availability`
+        ),
         icon: request.mentor?.profile_url || ""
       }
     })

--- a/src/services/notify/mentor/session.ts
+++ b/src/services/notify/mentor/session.ts
@@ -11,7 +11,9 @@ export async function notifySessionSlotSuggested(
   if (!request.mentee) return
 
   const siteLogo = getSiteLogoUrl()
-  const sessionLink = createAbsoluteUrl(`/mentors`)
+  const sessionLink = createAbsoluteUrl(
+    `/profile/${request.mentor_id}/availability`
+  )
   const mentorName = request.mentor
     ? `${request.mentor.first_name} ${request.mentor.last_name}`
     : "Your mentor"


### PR DESCRIPTION
**Update notification Url**

Instead of navigating to the Mentor Listing page, the mentee should be redirected to the mentor's calendar page for the specific mentor with whom they requested the session, so they can review and select one of the suggested time slots.